### PR TITLE
Stage 4 — Bayesian DSGE validity (v0.6.2): #128–#150

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # Threaded example blocks (pvar bootstrap) parallelize on the runner's 4 vCPUs,
+      # and verify_examples.jl needs >=2 threads for its per-block timeout watchdog.
+      JULIA_NUM_THREADS: "4"
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -39,6 +42,10 @@ jobs:
       # (any example failure) fails the job before deploy. No continue-on-error.
       - name: Verify documentation examples
         run: julia --project=docs docs/verify_examples.jl --all
+        env:
+          # Hosted runners are ~2x slower than local; 240 s still backstops real hangs
+          # (heaviest legitimate blocks: pvar.md bootstrap, tests_unitroot_advanced.md grid searches).
+          DOCS_VERIFY_TIMEOUT: "240"
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroEconometricModels"
 uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Wookyung Chung <chung@friedman.jp>"]
 
 [deps]

--- a/docs/plotrule.md
+++ b/docs/plotrule.md
@@ -1,0 +1,270 @@
+# Plot Style & Architecture Guide
+
+This guide defines the design and code-architecture standards for all plotting in MacroEconometricModels.jl — every `plot_result` method, every chart renderer, and every future plot feature. It plays the same role for plots that `docrule.md` plays for documentation pages: **new plot code must follow these rules, and existing plot code is reviewed against them.** The target quality is publication-grade econometrics graphics (FRED / BIS / central-bank working-paper level) delivered as self-contained interactive HTML.
+
+Terminology used throughout:
+
+- **Renderer** — a `_render_*_js` function that emits D3.js code for one chart form (line, area, bar, heatmap, scatter, coefficient plot).
+- **Data converter** — a `_*_data_json` helper that turns result-struct arrays into a JSON data string.
+- **Plot method** — a `plot_result(::SomeResult; kwargs...)` method that selects data, calls converters and renderers, assembles panels, and returns a `PlotOutput`.
+- **Panel** — one chart (`_PanelSpec`); a **figure** is one or more panels composed by `_make_plot`.
+
+---
+
+## Architecture
+
+The plotting module is a strict four-layer stack. Data flows down, never up or sideways:
+
+```
+types.jl     PlotOutput, _PanelSpec, theme constants (_PLOT_COLORS, _PLOT_FONT,
+             _PLOT_CI_ALPHA), _next_plot_id, the _json serializer
+render.jl    CSS, HTML skeleton, shared JS core, ALL chart renderers,
+             panel composition (_make_plot), save/display/show
+helpers.jl   ALL data converters (_irf_data_json, _fevd_data_json, ...),
+             _resolve_var, _series_json
+<domain>.jl  plot_result methods only (irf.jl, fevd.jl, hd.jl, filters.jl,
+             forecast.jl, models.jl, nowcast.jl, did.jl, reg.jl, spectral.jl, io.jl)
+```
+
+**A1 — Renderers live in `render.jl` and nowhere else.** A domain file must never define a `_render_*_js` function. If a domain file needs a chart form that doesn't exist, add the renderer to `render.jl` with full generic parameterization, then call it. (Historical violations to migrate: `_render_vbar_js` in spectral.jl, `_render_scatter_js` in did.jl, `_render_coef_plot_js` in reg.jl, `_render_occbin_panel_js` in models.jl.)
+
+**A2 — Renderers are domain-agnostic.** No domain vocabulary inside a renderer: tooltips, labels, and legends must be built from parameters (`xlabel`, series `name`s), never hardcoded nouns like "Lag", "Period", or "Shock". A renderer that says `'Period '+d.x` in its tooltip will eventually render "Period Agriculture" when reused for a sector heatmap. Tooltip prefix = the `xlabel` parameter (or a dedicated `tip_label` parameter), always.
+
+**A3 — One IIFE per panel; rely on IIFE scoping.** Every renderer wraps its JS in `(function() { ... })();`. Inside that wrapper, use plain identifiers (`data`, `x`, `y`, `svg`). Never suffix identifiers with the panel id (`data_$(id)`) — the IIFE already isolates scope, and suffixing bloats output and obscures diffs.
+
+**A4 — Never re-derive scales outside the renderer.** Post-hoc JS snippets that rebuild the margin object and x/y scales to overlay one extra element (a vertical line, a Q-Q reference line) duplicate renderer internals and silently break when the renderer changes. If a chart needs an overlay, the renderer grows an option:
+
+- Vertical reference lines: `ref_lines_json` entries carry `"axis":"x"` (the scatter renderer already supports this; the line renderer must too).
+- Sloped reference lines (Q-Q): a `line_overlays_json` option with `{x1, y1, x2, y2, color, dash}` in *data* coordinates, mapped through the renderer's own scales.
+
+**A5 — Plot methods do selection and assembly, not computation.** A `plot_result` method extracts arrays from the result struct, converts them with helpers, calls renderers, and composes panels. Statistical computation (KDE, histogram binning, z-scores, Lorenz accumulation, Gini) belongs in the owning computational module or a documented `_plot_*` helper directly above the method — never inline in the middle of panel assembly, and never duplicated between plotting and the analysis code that computes the same statistic for `report()`.
+
+**A6 — All data converters live in `helpers.jl`.** If a plot method builds `rows = Vector{Pair{String,String}}[]` inline, that loop should almost always be a named, documented converter in helpers.jl so the next result type with the same shape reuses it.
+
+**A7 — `_json` is the only serializer, and it must be total over what we feed it.**
+
+- Every value type passed to `_json` needs an explicit method (`AbstractString`, `Number`, `Bool`, `Symbol`, `Nothing`, `Missing`, `AbstractVector`, and `Date`/`DateTime` when date axes land). No `_json(::Any)` fallback — a `MethodError` at plot time is better than silently emitting invalid JSON.
+- `NaN`/`Inf` serialize to `null` (renderers must treat `null` as a gap via `.defined()`).
+- **No duplicate keys in one JSON object.** Building a row and then `push!`-ing a second pair with the same key (the forecast "bridge point" pattern) produces invalid JSON that only works by accident of browser parsing. Overwrite the existing pair instead.
+- String escaping must cover `\`, `"`, `\n`, `\r`, `\t`, all control characters < U+0020, and — because output is embedded in a `<script>` block — the sequences `</` (escape as `<\/`) and U+2028/U+2029.
+
+**A8 — Escape everything interpolated into HTML or JS.** User-controlled strings (variable names, shock names, titles, labels) reach three sinks, each with its own rule:
+
+| Sink | Rule |
+|---|---|
+| HTML text (`<div class="panel-title">$(title)</div>`) | pass through an `_esc_html` helper (`&`, `<`, `>`, `"`) |
+| JS string literal (`.text('$(xlabel)')`) | never interpolate raw into quoted JS; emit via `_json(xlabel)` so it arrives as a proper JSON string literal |
+| JSON data | already covered by `_json` |
+
+A variable named `GDP's "core"` or `x<y` must render, not break the document.
+
+**A9 — Every renderer ships complete.** A new renderer must provide: margins/responsive width, y-grid, axes with labels, tooltip, legend policy (below), `ref_lines_json` support where meaningful, band support where meaningful, and its own unit test. No "minimal for now" renderers.
+
+**A10 — No positional struct-literal adapters.** Converting one result type to another for plot reuse (e.g. LPDiD → EventStudyLP) must go through a keyword constructor or a dedicated `Base.convert`/`_as_eventstudy(...)` function owned by the struct's module. A positional literal with dummy fields breaks silently when the struct gains a field.
+
+**A11 — IDs and global JS state.** Panel DOM ids come from `_next_plot_id` only. All JS state lives inside the per-panel IIFE except the shared core (`fmt`, `showTip`, `hideTip`, `tooltip`), which must be embed-safe: guard against redefinition (`if (typeof window.__mem_core === 'undefined') { ... }`) and select the tooltip node relative to the plot container, not by a fixed global `#tooltip` id, so that two `PlotOutput`s displayed in the same notebook DOM don't collide. Note the `_plot_counter` `Ref` is *not* atomic; if plots are ever generated from threads, use `Threads.Atomic{Int}`.
+
+**A12 — Self-contained output.** A saved plot must render offline. D3 must be vendored (inlined into the HTML from a copy shipped with the package or an artifact), not loaded from a CDN `<script src>`. If a CDN fallback is kept for size reasons, it requires an SRI `integrity` attribute and a documented offline limitation — but vendoring is the rule. This also protects the Documenter site (iframes) from third-party outages.
+
+---
+
+## API Contract
+
+**C1 — One entry point.** Users plot any result with `plot_result(result; kwargs...)` returning a `PlotOutput`. Exported names are exactly: `plot_result`, `PlotOutput`, `save_plot`, `display_plot`. Everything else is internal (`_`-prefixed).
+
+**C2 — Standard keyword vocabulary.** Use these names with these exact semantics; never invent synonyms:
+
+| Kwarg | Type | Semantics |
+|---|---|---|
+| `var` | `Union{Int,String,Nothing}=nothing` | select one response variable; `nothing` = all |
+| `shock` | `Union{Int,String,Nothing}=nothing` | select one shock; `nothing` = all |
+| `vars` | `Union{Vector,Nothing}=nothing` | select multiple variables (data containers) |
+| `view` | `Symbol` | switch between named views of one result |
+| `ncols` | `Int=0` | grid columns; `0` = auto |
+| `title` | `String=""` | figure title; `""` = auto-generated |
+| `save_path` | `Union{String,Nothing}=nothing` | also write HTML to this path |
+| `history` / `n_history` | vector / `Int` | historical context for forecast fans |
+
+**C3 — Name selection works everywhere names exist.** Any `var`/`shock`/`vars` kwarg accepts **both** `Int` and `String` whenever the result carries names. `Union{Int,Nothing}`-only signatures (current FEVD, LPFEVD, VARForecast, BVARForecast, VECMForecast, LPForecast, FactorForecast) are contract violations to fix. Resolution goes through `_resolve_var`, which must also **bounds-check integer input** and throw a friendly `ArgumentError` (not a downstream `BoundsError`).
+
+**C4 — Every kwarg is live.** A keyword that the body never reads (`stat` in Bayesian FEVD/HD plots, `group_names` in the nowcast heatmap view) is forbidden: either implement it or remove it. Dead kwargs are worse than missing ones — they promise behavior that doesn't happen.
+
+**C5 — `view` dispatch pattern.** Multi-view results (`NowcastResult`, `NowcastNews`, `HASteadyState`) dispatch on `view::Symbol` and must throw `ArgumentError` listing all valid views for anything else. Each view gets a `_plot_<type>_<view>` helper. Kwargs that apply only to some views must be documented per-view, and a kwarg passed to a view that ignores it should be an error, not silence.
+
+**C6 — Docstrings tell the truth.** The docstring describes exactly what is drawn. If it says "vertical line at the posterior mean", "reference period marker", or "horizontal bar chart", the plot must contain a vertical line, a marker, and horizontal bars. Docstring/render mismatches are release blockers because users cite these plots.
+
+**C7 — No silent truncation.** Any cap (first 5 factors, 10 groups, 12 variables, 60 histogram bars, 10 eigenvalues) must be visible in the output — in the panel title (`"Extracted Factors (5 of 12)"`) or a figure note — and documented in the docstring, ideally with a kwarg to raise it. A reader must never believe they are seeing everything when they are not.
+
+**C8 — `save_path` semantics.** When given, write the file *and* return the `PlotOutput`. Never print, never open a browser implicitly (that is `display_plot`'s job).
+
+**C9 — Numbers in titles are formatted, not serialized.** Use `round`/`_fmt` (3–4 significant digits) for values embedded in titles or panel names. Never `_json(x)` into prose — it prints full float precision and renders `NaN` as `null`.
+
+---
+
+## Visual Design Rules
+
+### Form selection
+
+The data's job picks the chart form. The canonical mapping for this package:
+
+| Result | Form | Notes |
+|---|---|---|
+| IRF (all flavors) | line + CI band + zero line | horizon starts at **0** |
+| FEVD | stacked area, 0–100% | horizon starts at **1**; y ticks in % |
+| Historical decomposition | diverging stacked bar + actual/reconstructed line panel | zero line mandatory |
+| Event study (DiD, LP-DiD) | **point-and-whisker per event time** (coefplot), vertical line at treatment, zero line | a continuous ribbon over-smooths discrete coefficients; keep line+band only as an explicit `style=:ribbon` option |
+| Forecast | history line + fan (band) + point path | history context should be available for *every* forecast type, not only ARIMA |
+| Filter / decomposition | 2-panel: original+trend, cycle with zero line | |
+| ACF/PACF/CCF | thin vertical bars from zero + ±CI lines | lags start at 1 |
+| Spectral density | line + band, log₁₀ scale | frequency axis may add period annotations |
+| Volatility models | 3-panel: returns, σₜ, standardized residuals | |
+| Densities (prior/posterior) | line (KDE) + vertical mean/mode line | |
+| Coefficients / marginal effects / multipliers / news impacts | **horizontal** dot-and-whisker or bar when categories are named entities | names read horizontally; vertical bars with rotated or thinned name labels are forbidden |
+| Matrices (Leontief, correlation, z-scores) | heatmap **with a color legend** | |
+| Two-metric sector/group comparison (Rasmussen) | scatter + quadrant reference lines, direct labels | |
+| Distributions over a grid (HA wealth) | area/step density; bin-aggregate when subsampling, never point-sample | mass must be conserved in what is displayed |
+
+If the object is a single headline number (a nowcast, a breakdown value), it belongs in the title or a stat annotation — not a chart of one point.
+
+### Color
+
+- `_PLOT_COLORS` is the single categorical palette. **Assign hues in fixed order and keep color↔entity stable across all panels of a figure** (shock *j* keeps its color in every panel; a filtered replot must not repaint survivors).
+- More series than the palette → fold the tail into "Other" or split into small multiples. `mod1` recycling inside `_series_json` is a last-resort guard, not a design; and slicing `_PLOT_COLORS[1:n]` with `n > 20` is an error — always go through `_series_json`'s cycling or pre-check length.
+- **Sequential data gets a single-hue ramp** (light→dark). A nonnegative matrix (Leontief inverse) on a red-blue diverging scale is wrong: diverging palettes are reserved for signed data with a meaningful midpoint (z-scores, contributions), and the midpoint must map to the neutral center.
+- `#d62728`-class red is the *alert/reference* color (CI bounds, binding regions, treatment lines). Avoid it as an ordinary series color in any figure that also draws red reference elements.
+- CI bands use the parent line's color at `_PLOT_CI_ALPHA`. When two bands overlap (HonestDiD original vs robust), they must differ in **both** color and alpha, and both must appear in the legend.
+- Never encode meaning by color alone: dashed vs solid (already used for linear/piecewise, trend/original) is the required secondary channel; keep it.
+- The palette must be validated for color-vision deficiency once per change (dataviz validator or equivalent); record the result in this file. Pairs like green/red (#2ca02c/#d62728) must never be the only distinction between two adjacent series.
+
+### Reference lines and annotations
+
+- Zero line on every axis where sign matters: IRF, event study, cycle, HD contributions, news impacts, coefficient plots. (Currently missing on the HD actual-vs-reconstructed panel — add it.)
+- Event-time zero gets a vertical treatment line; ACF gets ±CI lines; OccBin gets binding-region shading. These are renderer options (A4), not post-hoc scripts.
+- The reference/normalized period in an event study is visually marked (hollow marker at the omitted category).
+
+### Axes, titles, legends
+
+- **Horizon conventions:** IRF x starts at 0; FEVD at 1; document any deviation in the docstring. Horizon, lag, and event-time axes force integer ticks — a tick at h = 2.5 is a bug.
+- **Date axes:** whenever the source object carries time metadata (`TimeSeriesData.time_index`, panel `time_id`, nowcast vintages), the x axis shows dates, not 1…T. Plots of HD/filters/forecasts over "Period 143" are unacceptable for empirical work; converters accept an optional `time_index` and `_json` learns `Date`. Where the estimation drops initial observations (VAR lags, Hamilton/BK trimming), the axis must reflect the *calendar* position of each point, which the `offset` mechanism must map correctly.
+- Every panel has x and y axis labels with units (`"Horizon (quarters)"` when known, `"Response (%)"` for percent-scaled IRFs).
+- Figure title = object + method + inference statement (`"Impulse Response Functions (bootstrap 90% CI)"`). Panel title = the specific slice (`"gdp ← monetary"` convention: *response ← shock*).
+- Single-panel figures must not repeat the same string as both figure title and panel title; give the panel a specific subtitle or suppress one.
+- **Legend policy:** ≥2 series → legend always; 1 series → no legend (the title names it). Legend layout must be width-aware — fixed 90–130 px steps overflow with long names; wrap to a second row or truncate with full name in the tooltip. A legend may hold at most ~6 entries; beyond that use direct labels (scatter) or fold categories.
+- Anything drawn that is not a series also needs a legend entry when ambiguous: overlapping CI bands, binding-region shading, equality lines.
+
+### Heatmaps
+
+- Always render a **color scale legend** (gradient bar with min/mid/max ticks). A heatmap without a scale is unreadable in print.
+- Missing values get the neutral grey plus a legend entry "missing".
+- Diverging scale ⇒ symmetric domain around the meaningful midpoint; sequential scale ⇒ `[0 or data-min, data-max]` single hue.
+
+---
+
+## Interaction
+
+- Every renderer ships a tooltip (crosshair-nearest for line/area, per-mark for bar/cell/point). Tooltip text is assembled from series names + `fmt()` values; prefix comes from `xlabel`/parameter (A2).
+- Hover targets are at least as large as the visual mark; scatter marks enlarge on hover (already standard — keep).
+- Interactivity degrades gracefully: the chart must be complete without hovering (tooltips reveal precision, never information that exists nowhere else). This is what makes the same HTML acceptable as a static screenshot in papers.
+
+---
+
+## Robustness
+
+Every plot method and renderer must survive, with sensible output:
+
+| Input | Required behavior |
+|---|---|
+| `NaN` / `Inf` / `missing` values | `null` in JSON → visible gap (`.defined()`), never a broken SVG path; never `undefined` reaching a scale (a *missing key* in a data row is a bug — emit explicit `null`) |
+| Empty series / single observation | no JS exception; degenerate extents padded (`\|\| 1` fallbacks) |
+| Flat (constant) series | padded y-domain, line visible mid-panel |
+| Names containing `'`, `"`, `<`, `&`, newlines, unicode | rendered verbatim, document intact (A8) |
+| Very long names | truncated with ellipsis in axis/legend, full name in tooltip |
+| More series than palette | fold or error per Color rules; never an out-of-bounds slice |
+| Huge N (scatter/Q-Q with 10⁵ points) | subsample to ≤ ~2,000 marks with a visible note (C7); never emit multi-MB JSON silently |
+| Wide panels (n_vars × n_shocks large) | cap the grid and say so (C7); flex-wrap must not silently destroy the shock-column alignment |
+| Misaligned auxiliary series (`original` shorter than trend+offset) | throw `ArgumentError` naming the expected length — never silently shift or truncate the drawn series |
+| Two plots in one notebook page | both render (A11) |
+
+Performance rule of thumb: data-assembly loops in Julia must be O(total points drawn); scanning the full panel per (group, time) cell (`findfirst` over N rows inside a t×g loop) is a defect — pre-index once.
+
+---
+
+## Theming & Accessibility
+
+- The HTML theme (background, ink colors, grid) is defined once in `_render_css` as CSS custom properties. Dark mode ships via `@media (prefers-color-scheme: dark)` overrides of those properties so docs iframes match the site's Solarized light/dark toggle; series colors get dark-surface-validated variants, not an automatic inversion.
+- Contrast: axis/label ink ≥ WCAG AA against both surfaces.
+- Print/export: the layout must not depend on hover; `svg { overflow: visible }` keeps legends printable.
+
+---
+
+## Testing Rules
+
+Every new or changed plot method requires tests in `test/plotting/`:
+
+1. **Smoke:** returns a `PlotOutput`; `save_path` writes a file that starts with `<!DOCTYPE html>`.
+2. **Content:** HTML contains the expected panel count, panel titles, series names, and auto-title.
+3. **Kwargs:** `var`/`shock` selection by Int *and* by String; bad name → `ArgumentError`; bad index → `ArgumentError`; `ncols`, `title` override, `view` dispatch incl. the error branch.
+4. **Data edge cases:** input containing `NaN` produces `null` (assert `"null"` present, no `"NaN"` in the JS); constant series; minimal length.
+5. **Escaping:** a variable named `a"b<c>` round-trips into valid HTML (no unescaped `<` inside the panel title element, no unescaped `"` inside script strings).
+6. **JSON validity:** embedded `const data = [...]` blocks parse as strict JSON (extract-and-parse in the test; duplicate keys fail).
+7. **Caps:** whatever C7 note the method emits is asserted.
+
+Renderer changes additionally require one test per option (bands, ref lines incl. `axis:"x"`, overlays, modes).
+
+---
+
+## Documentation Rules
+
+- Every `plot_result` method appears on `docs/src/plotting.md` with a generated example embedded per `docrule.md` ("Embedding Plot Iframes"). The page's supported-type count and dispatch table must match `length(methods(plot_result))` — generate the table with `@eval` rather than maintaining it by hand.
+- Example plots are produced by `docs/generate_plots.jl` — never hand-edited HTML — into `docs/src/assets/plots/`, and regenerated whenever plotting code changes (the release workflow's "regenerate plots if plotting/docs changed" step). Every generated asset is embedded by some page; orphan assets are deleted. The generator should run in CI as a smoke test so that plot methods without unit tests still get exercised.
+- The docstring lists every kwarg with defaults and states the visual anatomy (panels, lines, bands, reference marks) precisely (C6).
+
+---
+
+## Review Checklist
+
+Copy into the PR description for any change under `src/plotting/`:
+
+```
+Architecture
+[ ] Renderers only in render.jl; no domain nouns inside renderers
+[ ] No scale re-derivation outside renderers; overlays via renderer options
+[ ] Converters in helpers.jl; no inline row-building loops in plot methods
+[ ] All interpolated strings escaped (HTML sink, JS sink, JSON sink)
+[ ] No positional struct-literal adapters
+API
+[ ] plot_result only; standard kwarg names; String+Int selection; bounds-checked
+[ ] No dead kwargs; view dispatch errors on unknown views
+[ ] Docstring matches the pixels; numbers in titles rounded, not _json'd
+[ ] No silent caps — truncation visible in output
+Design
+[ ] Correct form for the data's job (table above)
+[ ] Fixed color order; entity-stable colors; no red-as-series next to red refs
+[ ] Sequential vs diverging palette matches data sign; heatmap has color legend
+[ ] Zero/reference lines present; axes labeled; integer ticks on horizon/lag axes
+[ ] Legend policy respected; width-aware; bands/shading legended when ambiguous
+Robustness & tests
+[ ] NaN/empty/flat/long-name/quote-in-name cases handled + tested
+[ ] Embedded JSON parses strictly; no duplicate keys
+[ ] Big-N subsampling with note where applicable
+[ ] test/plotting updated per Testing Rules
+```
+
+---
+
+## Anti-Patterns
+
+Concrete failures this guide exists to prevent (all observed in review):
+
+1. **The lying docstring** — "horizontal bar chart" rendered vertical; "vertical line at posterior mean" never drawn; "reference period marker" absent.
+2. **The leaked noun** — generic heatmap tooltip printing `Period Agriculture` because "Period" was hardcoded in the renderer.
+3. **The dead kwarg** — `stat=:mean` accepted and ignored; `group_names` accepted and ignored.
+4. **The duplicate-key bridge** — appending a second `"fc"` pair to a JSON row instead of replacing it.
+5. **The phantom original** — reconstructing `trend .+ cycle` and indexing it with the full-series offset, drawing a shifted, truncated "Original" line (Hamilton/BK without `original=`).
+6. **The scale clone** — post-hoc `<script>` that rebuilds margins and scales to add one vertical line, doubling the data payload and breaking on the next renderer edit.
+7. **The silent cap** — plotting 5 of 12 factors, 10 of 500 panel groups, or point-sampled 60 of 1000 grid masses with no indication.
+8. **The unrounded title** — `TWFE = 0.12345678901234567` via `_json` interpolation; `breakdown = null` when the value is `NaN`.
+9. **The legend march** — one legend entry per sector at fixed 130 px spacing, walking off the right edge of the panel.
+10. **The diverging rainbow** — RdBu on an all-positive matrix; midpoint at max/2 means nothing.
+11. **The CDN coin-flip** — plots blank on planes, behind proxies, and in archived supplementary materials because d3 came from a CDN.
+12. **The notebook collision** — second plot in a Jupyter page throws `Identifier 'tooltip' has already been declared`.

--- a/docs/src/dsge_ha.md
+++ b/docs/src/dsge_ha.md
@@ -486,7 +486,7 @@ using Distributions
 result = estimate_dsge_bayes(spec, data, [0.36];
     priors=Dict(:alpha => Beta(5, 2)),
     observables=[:K], n_draws=5000, burnin=1000,
-    ha_method=:ssj, ha_kwargs=(T_horizon=50, n_reduced=15))
+    ha_method=:ssj, ha_kwargs=(T_horizon=300, n_reduced=15))
 ```
 
 !!! note "Technical Note"
@@ -504,7 +504,7 @@ The estimation output is a `BayesianDSGE` object with posterior draws, acceptanc
 | `n_draws` | `Int` | `5000` | Total RWMH draws |
 | `burnin` | `Int` | `1000` | Burn-in draws to discard |
 | `ha_method` | `Symbol` | `:ssj` | Aggregate solution method (`:ssj` or `:reiter`) |
-| `ha_kwargs` | `NamedTuple` | `()` | Keyword arguments passed to `solve` |
+| `ha_kwargs` | `NamedTuple` | `(T_horizon=300, n_reduced=15)` | `solve` options. `T_horizon` sets the SSJ truncation length; too-small values truncate persistent HA Jacobians and bias the likelihood (default follows Auclert et al. 2021) |
 
 ---
 

--- a/docs/src/pvar.md
+++ b/docs/src/pvar.md
@@ -21,6 +21,7 @@ _df.id = _pd_raw.group_id
 _df.time = _pd_raw.time_id
 _mask = [all(isfinite, row) for row in eachrow(Matrix(_df[:, _dep_vars]))]
 _df = _df[_mask, :]
+_df = _df[_df.time .> maximum(_df.time) - 30, :]
 pd = xtset(_df, :id, :time)
 ```
 

--- a/docs/src/tests_unitroot_advanced.md
+++ b/docs/src/tests_unitroot_advanced.md
@@ -12,7 +12,7 @@ Standard unit root tests (ADF, PP, KPSS) perform well when the data-generating p
 using MacroEconometricModels, Random
 Random.seed!(42)
 fred = load_example(:fred_md)
-cpi = filter(isfinite, fred[:, "CPIAUCSL"])
+cpi = filter(isfinite, fred[:, "CPIAUCSL"])[end-299:end]
 ```
 
 ## Quick Start

--- a/docs/verify_examples.jl
+++ b/docs/verify_examples.jl
@@ -162,7 +162,9 @@ function verify_file(mdfile::String)
             # @example blocks (@setup output is never rendered).
             if b.kind === :example
                 try
-                    show(devnull, MIME"text/plain"(), payload)
+                    # invokelatest: the block's `using` runs inside this function's call,
+                    # so package show methods are newer than our frozen world age.
+                    Base.invokelatest(show, devnull, MIME"text/plain"(), payload)
                 catch se
                     nfail += 1
                     println("  ✗ $(loc): SHOW/display ERROR ($(elapsed)s)")

--- a/src/dsge/analytical.jl
+++ b/src/dsge/analytical.jl
@@ -53,6 +53,66 @@ solve_lyapunov(G1::AbstractMatrix{<:Real}, impact::AbstractMatrix{<:Real}) =
     solve_lyapunov(Float64.(G1), Float64.(impact))
 
 """
+    _lyapunov_from_cov(A, C) -> P
+
+Internal: solve the discrete Lyapunov equation `A P A' - P + C = 0` for a **stable**
+`A` (all `|eig(A)| < 1`) given the covariance-form driving term `C` (as opposed to
+`solve_lyapunov`, which takes an impact matrix and forms `C = impact*impact'`). Used
+for the stationary subspace inside `_diffuse_initial_covariance`.
+"""
+function _lyapunov_from_cov(A::AbstractMatrix{T}, C::AbstractMatrix{T}) where {T<:AbstractFloat}
+    n = size(A, 1)
+    n == 0 && return zeros(T, 0, 0)
+    M = Matrix{T}(I, n*n, n*n) - kron(A, A)
+    P = reshape(M \ vec(C), n, n)
+    return (P + P') / 2
+end
+
+"""
+    _diffuse_initial_covariance(G1, RQR; kappa=1e6, tol=1e-6) -> P0
+
+Internal: eigenvalue-partitioned diffuse initial state covariance for the Kalman
+filter/smoother when the transition matrix `G1` has unit roots (Durbin & Koopman
+2012, ch. 5; Dynare `lik_init=3`). Detects nonstationary directions (Schur
+eigenvalues with modulus `≥ 1 - tol`), applies a large diffuse variance `kappa` on
+that subspace and the finite stationary Lyapunov covariance (driven by `RQR = R Q R'`)
+on the complement. If `G1` is fully stable this reduces to the stationary solution.
+
+This is the finite-`kappa` approximation to exact diffuse initialization (the exact
+diffuse recursion is deferred to the consolidated Kalman kernel, [T147]); it replaces
+the old scale-dependent `P0 = 10*I` fallback and emits a one-time warning.
+"""
+function _diffuse_initial_covariance(G1::AbstractMatrix{T}, RQR::AbstractMatrix{T};
+                                      kappa::T=T(1e6), tol::T=T(1e-6)) where {T<:AbstractFloat}
+    n = size(G1, 1)
+    n == 0 && return zeros(T, 0, 0)
+    Sch = schur(Matrix{T}(G1))
+    nonstat = abs.(Sch.values) .>= (one(T) - tol)
+    d = count(nonstat)
+    if d == 0
+        return _lyapunov_from_cov(G1, RQR)
+    end
+    @warn "Diffuse Kalman init: $d nonstationary direction(s) (|eig|≥1); κ=$(kappa) diffuse " *
+          "prior on that subspace (P0=10*I removed; exact diffuse à la Durbin-Koopman 2012 " *
+          "ch.5 deferred to [T147])." maxlog=1
+    ordschur!(Sch, nonstat)           # nonstationary block first
+    U = Sch.Z
+    Qrot = U' * RQR * U
+    Prot = zeros(T, n, n)
+    for i in 1:d
+        Prot[i, i] = kappa
+    end
+    if d < n
+        S22 = Sch.T[d+1:n, d+1:n]
+        Q22 = Qrot[d+1:n, d+1:n]
+        Q22 = (Q22 + Q22') / 2
+        Prot[d+1:n, d+1:n] .= _lyapunov_from_cov(S22, Q22)
+    end
+    P0 = U * Prot * U'
+    return (P0 + P0') / 2
+end
+
+"""
     analytical_moments(sol::DSGESolution{T}; lags::Int=1) -> Vector{T}
 
 Compute analytical moment vector from a solved DSGE model.

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -264,7 +264,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                                             solver, solver_kwargs)
 
     else  # :mh
-        draws, log_posterior, acceptance_rate = _mh_sample(
+        draws, log_posterior, acceptance_rate, _mh_diag = _mh_sample(
             spec, data_mat, param_names, prior, theta0_sorted;
             n_draws=n_draws, burnin=burnin,
             observables=observables,

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -63,6 +63,78 @@ function _infer_prior_bounds(d::Distribution)
 end
 
 # =============================================================================
+# Helper: resolve theta0 (positional / Dict / NamedTuple) onto sorted params
+# =============================================================================
+
+"""
+    _resolve_theta0(theta0, param_names, ::Type{T}) -> Vector{T}
+
+Resolve the initial parameter vector against the (alphabetically sorted) prior
+parameter names (E-12 / H-12 / #136).
+
+- `Dict{Symbol}` / `NamedTuple`: build the internal vector by looking up each name
+  in `param_names`, so the input is **order-independent**. Errors if any prior
+  parameter is missing from `theta0`, or if `theta0` names a parameter not in the
+  priors.
+- `AbstractVector`: used positionally and **must be in sorted prior-key order**;
+  its length must equal `length(param_names)`, else an `ArgumentError` naming the
+  expected parameters is thrown (previously a wrong length failed opaquely much
+  later, and a mis-ordered vector was silently permuted onto the wrong parameters).
+"""
+function _resolve_theta0(theta0, param_names::Vector{Symbol}, ::Type{T}) where {T}
+    if theta0 isa AbstractDict || theta0 isa NamedTuple
+        for k in keys(theta0)
+            k in param_names || throw(ArgumentError(
+                "theta0 names unknown parameter :$k; the estimated parameters " *
+                "(sorted) are $(param_names)."))
+        end
+        out = Vector{T}(undef, length(param_names))
+        for (i, pn) in enumerate(param_names)
+            haskey(theta0, pn) || throw(ArgumentError(
+                "theta0 is missing parameter :$pn; provide all of $(param_names)."))
+            out[i] = T(theta0[pn])
+        end
+        return out
+    else
+        v = collect(theta0)
+        length(v) == length(param_names) || throw(ArgumentError(
+            "theta0 has length $(length(v)) but the model has $(length(param_names)) " *
+            "estimated parameters. Pass a positional vector in sorted prior-key order " *
+            "$(param_names), or a Dict/NamedTuple (order-independent)."))
+        return T.(v)
+    end
+end
+
+"""
+    _orient_data(data, n_obs, ::Type{T}) -> Matrix{T}
+
+Resolve data orientation by matching a dimension to `n_obs` (the number of
+observables), NOT by comparing the two dimensions (E-18 / #142). The public
+convention is `T×n` (time in rows, variables in columns); the Kalman/PF routines
+expect `n_obs × T_obs` internally, so:
+
+- `size(data, 2) == n_obs`  → `T×n`, transpose to `n_obs × T_obs`;
+- `size(data, 1) == n_obs`  → already `n_obs × T_obs`, use as-is;
+- otherwise                 → `ArgumentError` naming `n_obs` and the received shape.
+
+The only genuinely ambiguous case is `T == n_obs` (both dimensions equal `n_obs`);
+it is resolved as `T×n` (rows = time), consistent with the package convention.
+"""
+function _orient_data(data::AbstractMatrix, n_obs::Int, ::Type{T}) where {T}
+    dm = Matrix{T}(data)
+    nrows, ncols = size(dm)
+    if ncols == n_obs
+        return Matrix{T}(dm')          # T×n (convention) → n_obs × T_obs
+    elseif nrows == n_obs
+        return dm                       # already n_obs × T_obs
+    else
+        throw(ArgumentError(
+            "data has shape $(size(data)) but neither dimension equals the number of " *
+            "observables n_obs=$n_obs. Pass data as T×n (time in rows, variables in columns)."))
+    end
+end
+
+# =============================================================================
 # Main public API
 # =============================================================================
 
@@ -74,8 +146,13 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
 
 # Arguments
 - `spec::DSGESpec{T}` — model specification from `@dsge` macro
-- `data::AbstractMatrix` — observed data (T_obs × n_obs or n_obs × T_obs, auto-detected)
-- `θ0::AbstractVector{<:Real}` — initial parameter guess (length must match number of priors)
+- `data::AbstractMatrix` — observed data in `T×n` (time in rows, variables in columns),
+  the package convention; orientation is resolved by matching a dimension to the number
+  of observables (an `n×T` matrix is accepted and transposed internally).
+- `θ0` — initial parameter guess. Preferred: a `Dict{Symbol}`/`NamedTuple` keyed by
+  parameter name (order-independent). A positional `AbstractVector` is also accepted but
+  **must be in sorted (alphabetical) prior-key order** and its length must equal the
+  number of estimated parameters (otherwise an informative `ArgumentError` is thrown).
 
 # Keywords
 - `priors::Dict{Symbol,<:Distribution}` — prior distributions keyed by parameter name
@@ -109,7 +186,8 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
   *Econometric Reviews*, 26(2-4), 113-172.
 """
 function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
-                              theta0::AbstractVector{<:Real};
+                              theta0::Union{AbstractVector{<:Real},
+                                            AbstractDict{Symbol,<:Real},NamedTuple};
                               priors::Dict{Symbol,<:Distribution},
                               method::Symbol=:smc,
                               observables::Vector{Symbol}=Symbol[],
@@ -142,10 +220,9 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
     # ── 2. Sort param_names to match DSGEPrior ordering ──────────────────
     param_names = prior.param_names  # already sorted by DSGEPrior constructor
 
-    # Sort theta0 to match param_names ordering
-    prior_keys_sorted = param_names
-    # theta0 is provided in the same order as the sorted prior keys
-    theta0_sorted = T.(theta0)
+    # Resolve theta0: Dict/NamedTuple by name (order-independent), or a positional
+    # vector in sorted prior-key order with length validation (E-12 / #136).
+    theta0_sorted = _resolve_theta0(theta0, param_names, T)
 
     # ── 3. Handle observables ────────────────────────────────────────────
     if isempty(observables)
@@ -153,20 +230,9 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
     end
     n_obs = length(observables)
 
-    # ── 4. Data handling: ensure n_obs × T_obs format ────────────────────
-    data_mat = Matrix{T}(data)
-    nrows, ncols = size(data_mat)
-    # The Kalman filter expects n_obs × T_obs (each column is one time period)
-    # simulate() returns T_periods × n_endog
-    # If data has more rows than columns and nrows != n_obs, transpose
-    if nrows != n_obs && ncols == n_obs
-        data_mat = Matrix{T}(data_mat')
-    elseif nrows != n_obs && ncols != n_obs
-        # Neither dimension matches n_obs; try best guess: if nrows > ncols, transpose
-        if nrows > ncols
-            data_mat = Matrix{T}(data_mat')
-        end
-    end
+    # ── 4. Data handling: resolve orientation by matching n_obs (E-18 / #142) ─
+    # Public convention is T×n; Kalman/PF expect n_obs × T_obs internally.
+    data_mat = _orient_data(data, n_obs, T)
 
     # ── 5. Validate method ───────────────────────────────────────────────
     if method ∉ (:smc, :smc2, :mh)

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -204,6 +204,14 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
   (Christen & Fox 2005). Pre-screens proposals with a cheap bootstrap PF to avoid
   expensive CSMC evaluations on proposals that would be rejected. Exact posterior.
 - `n_screen::Int=200` — particles for screening PF (only used when `delayed_acceptance=true`)
+- `max_stages::Int=500` — hard cap on adaptive-tempering stages (`:smc`/`:smc2`); exceeding
+  it raises an error, guarding a degenerate likelihood that never advances φ→1 (Herbst &
+  Schorfheide 2016 use ~200–500 fixed stages)
+- `min_dphi::Real=1e-10` — minimum tempering step (`:smc`/`:smc2`); if the adaptive Δφ falls
+  below this while φ<1, estimation aborts with an informative error rather than spinning. The
+  default is deliberately small: informative likelihoods legitimately take small first steps
+  (e.g. ~1e-8), so this only trips on genuine numerical degeneracy (the bisection returning
+  ~1e-12); `max_stages` is the primary loop bound
 - `rng::AbstractRNG=Random.default_rng()` — random number generator
 
 # Returns
@@ -234,6 +242,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               solver_kwargs::NamedTuple=NamedTuple(),
                               delayed_acceptance::Bool=false,
                               n_screen::Int=200,
+                              max_stages::Int=500, min_dphi::Real=1e-10,
                               rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
 
     # ── 1. Build DSGEPrior from priors dict ──────────────────────────────
@@ -290,7 +299,8 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                              n_smc=n_smc, n_mh_steps=n_mh_steps,
                              ess_target=ess_target, observables=observables,
                              measurement_error=measurement_error,
-                             solver=solver, solver_kwargs=solver_kwargs, rng=rng)
+                             solver=solver, solver_kwargs=solver_kwargs,
+                             max_stages=max_stages, min_dphi=min_dphi, rng=rng)
         return _smc_state_to_bayesian_dsge(state, prior, param_names, spec, :smc,
                                             observables, measurement_error,
                                             solver, solver_kwargs)
@@ -303,7 +313,8 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               measurement_error=measurement_error,
                               solver=solver, solver_kwargs=solver_kwargs,
                               delayed_acceptance=delayed_acceptance,
-                              n_screen=n_screen, rng=rng)
+                              n_screen=n_screen,
+                              max_stages=max_stages, min_dphi=min_dphi, rng=rng)
         return _smc_state_to_bayesian_dsge(state, prior, param_names, spec, :smc2,
                                             observables, measurement_error,
                                             solver, solver_kwargs)

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -525,20 +525,16 @@ function posterior_summary(result::BayesianDSGE{T}) where {T<:AbstractFloat}
     for i in 1:n_params
         pn = result.param_names[i]
         draws_i = result.theta_draws[:, i]
-        sorted = sort(draws_i)
-        n = length(sorted)
 
-        # Quantile indices
-        idx_025 = max(1, round(Int, 0.025 * n))
-        idx_50 = max(1, round(Int, 0.50 * n))
-        idx_975 = min(n, round(Int, 0.975 * n))
-
+        # Interpolated quantiles via Statistics.quantile rather than ad-hoc order-statistic
+        # indexing (E-20 / #144). The stored draws are unweighted after the SMC terminal
+        # resample (E-09 / #132), so a plain quantile is correct.
         summary[pn] = Dict{Symbol, T}(
             :mean => mean(draws_i),
-            :median => sorted[idx_50],
+            :median => quantile(draws_i, 0.5),
             :std => std(draws_i),
-            :ci_lower => sorted[idx_025],
-            :ci_upper => sorted[idx_975]
+            :ci_lower => quantile(draws_i, 0.025),
+            :ci_upper => quantile(draws_i, 0.975)
         )
     end
 

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -134,6 +134,34 @@ function _orient_data(data::AbstractMatrix, n_obs::Int, ::Type{T}) where {T}
     end
 end
 
+"""
+    _resolve_measurement_error(measurement_error, data_mat, observables) -> Union{Nothing, Vector}
+
+Resolve the `measurement_error` keyword before it reaches the observation-equation
+builders. `nothing` passes through (zero ME). `:auto` scales measurement error to
+each observable's own variance — √(0.1·var(yᵢ)) per series (DSGE.jl/Dynare heuristic),
+which fixes the HA magnitude problem where aggregate observables span different scales
+— and emits a warning. A vector passes through as-is. Any other symbol errors.
+`data_mat` is n_obs × T_obs.
+"""
+function _resolve_measurement_error(measurement_error, data_mat::AbstractMatrix{T},
+                                     observables::Vector{Symbol}) where {T<:AbstractFloat}
+    measurement_error === nothing && return nothing
+    if measurement_error isa Symbol
+        measurement_error === :auto || throw(ArgumentError(
+            "measurement_error Symbol must be :auto, got :$measurement_error"))
+        n = size(data_mat, 1)
+        me = Vector{T}(undef, n)
+        for i in 1:n
+            me[i] = sqrt(T(0.1) * var(view(data_mat, i, :)))
+        end
+        @warn "measurement_error=:auto: added per-observable measurement error at 10% of " *
+              "each series' variance" observables sds=me
+        return me
+    end
+    return Vector{T}(measurement_error)
+end
+
 # =============================================================================
 # Main public API
 # =============================================================================
@@ -166,7 +194,9 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
 - `burnin::Int=5000` — burn-in draws discarded from `:mh` output; the posterior uses `n_draws - burnin`
 - `keep_burnin::Bool=false` — if true, retain the full `:mh` chain (e.g. for trace plots)
 - `ess_target::Float64=0.5` — target ESS fraction for adaptive tempering
-- `measurement_error::Union{Nothing,Vector{<:Real}}=nothing` — measurement error SDs
+- `measurement_error::Union{Nothing,Symbol,Vector{<:Real}}=nothing` — measurement error SDs;
+  `nothing` means zero ME (requires `n_obs ≤ n_shocks`, else a `StochasticSingularityError`
+  is thrown); `:auto` adds per-observable ME at 10% of each series' variance with a warning
 - `likelihood::Symbol=:auto` — likelihood evaluation method (currently auto = Kalman)
 - `solver::Symbol=:gensys` — DSGE solver method
 - `solver_kwargs::NamedTuple=NamedTuple()` — additional solver keyword arguments
@@ -198,7 +228,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               burnin::Int=5000,
                               keep_burnin::Bool=false,
                               ess_target::Float64=0.5,
-                              measurement_error::Union{Nothing,Vector{<:Real}}=nothing,
+                              measurement_error::Union{Nothing,Symbol,Vector{<:Real}}=nothing,
                               likelihood::Symbol=:auto,
                               solver::Symbol=:gensys,
                               solver_kwargs::NamedTuple=NamedTuple(),
@@ -233,6 +263,21 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
     # ── 4. Data handling: resolve orientation by matching n_obs (E-18 / #142) ─
     # Public convention is T×n; Kalman/PF expect n_obs × T_obs internally.
     data_mat = _orient_data(data, n_obs, T)
+
+    # Resolve :auto measurement error against data variance (per-observable). (#141/T042)
+    measurement_error = _resolve_measurement_error(measurement_error, data_mat, observables)
+
+    # Stochastic-singularity guard: with no measurement error and more observables than
+    # structural shocks, the model-implied observation covariance is singular. Checked
+    # eagerly here (spec.n_exog is exact and free) because the sampler closures would
+    # otherwise swallow the builder-thrown error via their per-θ catch. (#141/T042)
+    if measurement_error === nothing && n_obs > spec.n_exog
+        throw(StochasticSingularityError(
+            "$n_obs observables exceed $(spec.n_exog) structural shocks; the model-implied " *
+            "observation covariance is singular and the likelihood is ill-defined. " *
+            "Add measurement error (measurement_error=:auto or a vector of SDs) or " *
+            "reduce the number of observables."))
+    end
 
     # ── 5. Validate method ───────────────────────────────────────────────
     if method ∉ (:smc, :smc2, :mh)

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -370,16 +370,17 @@ function _smc_state_to_bayesian_dsge(state::SMCState{T}, prior::DSGEPrior{T},
         end
     end
 
-    sol, ss = _build_solution_at_theta(spec, param_names, theta_mean,
-                                        observables, measurement_error,
-                                        solver, solver_kwargs)
+    sol, ss, solved_at = _build_solution_mean_or_hpd(spec, param_names, theta_mean,
+                                                      theta_draws, log_posterior,
+                                                      observables, measurement_error,
+                                                      solver, solver_kwargs)
 
     BayesianDSGE{T}(
         theta_draws, log_posterior, param_names, prior,
         state.log_marginal_likelihood, method_sym, acceptance_rate,
         state.ess_history, state.phi_schedule,
         spec, sol, ss,
-        state.n_lik_failures, state.n_lik_evals
+        state.n_lik_failures, state.n_lik_evals, solved_at
     )
 end
 
@@ -489,9 +490,10 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
     # Posterior mean from draws
     theta_mean = vec(mean(draws; dims=1))
 
-    sol, ss = _build_solution_at_theta(spec, param_names, theta_mean,
-                                        observables, measurement_error,
-                                        solver, solver_kwargs)
+    sol, ss, solved_at = _build_solution_mean_or_hpd(spec, param_names, theta_mean,
+                                                      draws, log_posterior,
+                                                      observables, measurement_error,
+                                                      solver, solver_kwargs)
 
     # Log marginal likelihood via Geweke (1999) modified harmonic mean (E-04 / #130).
     # `log_posterior` stores the per-draw kernel log L(θ) + log π(θ), on the same
@@ -505,7 +507,7 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
         log_ml, :rwmh, acceptance_rate,
         T[], T[],  # no ESS history or phi schedule for MH
         spec, sol, ss,
-        n_failed, n_evals
+        n_failed, n_evals, solved_at
     )
 end
 
@@ -550,6 +552,66 @@ function _build_solution_at_theta(spec::DSGESpec{T}, param_names::Vector{Symbol}
     end
 
     return sol, ss
+end
+
+"""
+    _try_build_solution(spec, param_names, theta, observables, measurement_error,
+                         solver, solver_kwargs) -> Union{Nothing, Tuple}
+
+Build the solution/state space at `theta`, returning `nothing` on a narrow DSGE-solve
+failure — a benign per-θ numeric error (`_benign_solve_error`) OR a returned-but-
+indeterminate linear solution (an indeterminate model does NOT throw; `solve` returns
+a `DSGESolution` with `is_determined == false`). Non-benign exceptions propagate.
+"""
+function _try_build_solution(spec::DSGESpec{T}, param_names::Vector{Symbol},
+                              theta::Vector{T}, observables::Vector{Symbol},
+                              measurement_error, solver::Symbol,
+                              solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+    local sol, ss
+    try
+        sol, ss = _build_solution_at_theta(spec, param_names, theta,
+                                            observables, measurement_error,
+                                            solver, solver_kwargs)
+    catch err
+        _benign_solve_error(err) && return nothing
+        rethrow(err)
+    end
+    if sol isa DSGESolution && !is_determined(sol)
+        return nothing
+    end
+    return (sol, ss)
+end
+
+"""
+    _build_solution_mean_or_hpd(spec, param_names, theta_mean, theta_draws,
+                                 log_posterior, observables, measurement_error,
+                                 solver, solver_kwargs) -> (sol, ss, solved_at)
+
+Build the result-container solution at the posterior mean; if the mean is
+indeterminate / fails to solve (common for multimodal or boundary posteriors), fall
+back to the **highest-posterior draw** — the whole estimation no longer errors after
+sampling succeeded. Returns the solution, state space, and a `solved_at` marker
+(`:posterior_mean` or `:highest_posterior_draw`).
+"""
+function _build_solution_mean_or_hpd(spec::DSGESpec{T}, param_names::Vector{Symbol},
+                                      theta_mean::Vector{T}, theta_draws::Matrix{T},
+                                      log_posterior::Vector{T}, observables::Vector{Symbol},
+                                      measurement_error, solver::Symbol,
+                                      solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+    result = _try_build_solution(spec, param_names, theta_mean, observables,
+                                  measurement_error, solver, solver_kwargs)
+    if result !== nothing
+        sol, ss = result
+        return sol, ss, :posterior_mean
+    end
+    idx = argmax(log_posterior)
+    theta_hpd = Vector{T}(@view theta_draws[idx, :])
+    @warn "Posterior-mean solve failed/indeterminate; building the result container at " *
+          "the highest-posterior draw (index $idx). IRFs/FEVDs reflect that draw, not the " *
+          "posterior mean — see result.solved_at."
+    sol, ss = _build_solution_at_theta(spec, param_names, theta_hpd, observables,
+                                        measurement_error, solver, solver_kwargs)
+    return sol, ss, :highest_posterior_draw
 end
 
 # =============================================================================
@@ -1010,6 +1072,7 @@ function Base.show(io::IO, result::BayesianDSGE{T}) where {T}
         "Tempering stages"     length(result.phi_schedule);
         "Failed lik. evals"    string(result.n_failed_draws, " / ", result.n_lik_evals,
                                         " (", fail_share, "%)");
+        "Solution built at"    string(result.solved_at);
     ]
     _pretty_table(io, spec_data;
         title="Bayesian DSGE Estimation",

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -281,7 +281,8 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
         return _mh_to_bayesian_dsge(draws, log_posterior, acceptance_rate,
                                      prior, param_names, spec,
                                      observables, measurement_error,
-                                     solver, solver_kwargs)
+                                     solver, solver_kwargs,
+                                     _mh_diag.n_failed, _mh_diag.n_evals)
     end
 end
 
@@ -332,7 +333,8 @@ function _smc_state_to_bayesian_dsge(state::SMCState{T}, prior::DSGEPrior{T},
         theta_draws, log_posterior, param_names, prior,
         state.log_marginal_likelihood, method_sym, acceptance_rate,
         state.ess_history, state.phi_schedule,
-        spec, sol, ss
+        spec, sol, ss,
+        state.n_lik_failures, state.n_lik_evals
     )
 end
 
@@ -436,7 +438,9 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
                                 observables::Vector{Symbol},
                                 measurement_error,
                                 solver::Symbol,
-                                solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+                                solver_kwargs::NamedTuple,
+                                n_failed::Int=0,
+                                n_evals::Int=0) where {T<:AbstractFloat}
     # Posterior mean from draws
     theta_mean = vec(mean(draws; dims=1))
 
@@ -455,7 +459,8 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
         draws, log_posterior, param_names, prior,
         log_ml, :rwmh, acceptance_rate,
         T[], T[],  # no ESS history or phi schedule for MH
-        spec, sol, ss
+        spec, sol, ss,
+        n_failed, n_evals
     )
 end
 
@@ -652,7 +657,9 @@ function posterior_predictive(result::BayesianDSGE{T}, n_sim::Int;
     # Determine number of variables from spec
     n_vars = spec.augmented ? length(spec.original_endog) : spec.n_endog
 
-    paths = zeros(T, n_sim, T_periods, n_vars)
+    # Collect one path per SUCCESSFUL draw; failed draws are DROPPED (not zero-filled,
+    # which would bias the predictive distribution toward zero).
+    paths_list = Vector{Matrix{T}}()
 
     for s in 1:n_sim
         # Randomly select a posterior draw
@@ -671,14 +678,24 @@ function posterior_predictive(result::BayesianDSGE{T}, n_sim::Int;
             new_spec = compute_steady_state(new_spec)
             sol = solve(new_spec; method=:gensys)
             if is_determined(sol)
-                sim = simulate(sol, T_periods; rng=rng)
-                # simulate returns T_periods × n_vars
-                paths[s, :, :] = sim
+                sim = simulate(sol, T_periods; rng=rng)  # T_periods × n_vars
+                push!(paths_list, Matrix{T}(sim))
             end
-        catch
-            # Leave as zeros for failed simulations
+        catch e
+            _benign_solve_error(e) || rethrow(e)
             continue
         end
+    end
+
+    n_valid = length(paths_list)
+    n_dropped = n_sim - n_valid
+    n_dropped > 0 && @warn "posterior_predictive: dropped $(n_dropped)/$(n_sim) draws " *
+        "($(round(100*n_dropped/n_sim; digits=1))%) that failed to solve."
+
+    # Stack into (n_valid × T_periods × n_vars); first dim is successful draws only.
+    paths = Array{T,3}(undef, n_valid, T_periods, n_vars)
+    for s in 1:n_valid
+        paths[s, :, :] = paths_list[s]
     end
 
     return paths
@@ -741,12 +758,16 @@ function irf(result::BayesianDSGE{T}, horizon::Int;
                 irf_i = irf(sol, horizon)
                 push!(all_irfs, irf_i.values)
             end
-        catch
+        catch e
+            _benign_solve_error(e) || rethrow(e)
             continue
         end
     end
 
     n_valid = length(all_irfs)
+    n_skipped = n_sim - n_valid
+    n_skipped > 0 && @warn "Bayesian IRF: skipped $(n_skipped)/$(n_sim) posterior draws " *
+        "($(round(100*n_skipped/n_sim; digits=1))%) that failed to solve; bands conditioned on $(n_valid) draws."
     n_valid == 0 && error("All posterior draws failed to produce valid IRFs")
 
     # Stack into (n_valid x H x n_vars x n_shocks) array
@@ -815,12 +836,16 @@ function fevd(result::BayesianDSGE{T}, horizon::Int;
                 fevd_i = fevd(sol, horizon)
                 push!(all_fevds, fevd_i.proportions)
             end
-        catch
+        catch e
+            _benign_solve_error(e) || rethrow(e)
             continue
         end
     end
 
     n_valid = length(all_fevds)
+    n_skipped = n_sim - n_valid
+    n_skipped > 0 && @warn "Bayesian FEVD: skipped $(n_skipped)/$(n_sim) posterior draws " *
+        "($(round(100*n_skipped/n_sim; digits=1))%) that failed to solve; bands conditioned on $(n_valid) draws."
     n_valid == 0 && error("All posterior draws failed to produce valid FEVDs")
 
     # Stack: FEVD proportions are (n_vars x n_shocks x horizon)
@@ -889,12 +914,16 @@ function simulate(result::BayesianDSGE{T}, T_periods::Int;
                 sim = simulate(sol, T_periods; rng=rng)
                 push!(all_paths_list, sim)
             end
-        catch
+        catch e
+            _benign_solve_error(e) || rethrow(e)
             continue
         end
     end
 
     n_valid = length(all_paths_list)
+    n_skipped = n_sim - n_valid
+    n_skipped > 0 && @warn "Bayesian simulate: skipped $(n_skipped)/$(n_sim) posterior draws " *
+        "($(round(100*n_skipped/n_sim; digits=1))%) that failed to solve; bands conditioned on $(n_valid) draws."
     n_valid == 0 && error("All posterior draws failed to produce valid simulations")
 
     # Stack into (n_valid x T_periods x n_vars)
@@ -925,6 +954,8 @@ function Base.show(io::IO, result::BayesianDSGE{T}) where {T}
     ps = posterior_summary(result)
 
     # Summary table
+    fail_share = result.n_lik_evals > 0 ?
+        round(100 * result.n_failed_draws / result.n_lik_evals; digits=1) : 0.0
     spec_data = Any[
         "Method"                string(result.method);
         "Parameters"            n_params;
@@ -932,6 +963,8 @@ function Base.show(io::IO, result::BayesianDSGE{T}) where {T}
         "Log marginal lik."    round(result.log_marginal_likelihood; digits=4);
         "Acceptance rate"      round(result.acceptance_rate; digits=4);
         "Tempering stages"     length(result.phi_schedule);
+        "Failed lik. evals"    string(result.n_failed_draws, " / ", result.n_lik_evals,
+                                        " (", fail_share, "%)");
     ]
     _pretty_table(io, spec_data;
         title="Bayesian DSGE Estimation",

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -271,6 +271,87 @@ function _smc_state_to_bayesian_dsge(state::SMCState{T}, prior::DSGEPrior{T},
 end
 
 # =============================================================================
+# Internal: Geweke (1999) modified harmonic mean marginal-likelihood estimator
+# =============================================================================
+
+"""
+    _geweke_mhm(draws, log_post_kernel; p=0.5) -> T
+
+Geweke (1999) modified harmonic mean (MHM) estimator of the **log marginal
+likelihood** from posterior draws — the Dynare-standard estimator for MCMC output.
+
+Arguments
+- `draws::AbstractMatrix{T}` — `S×d` matrix of post-burn-in posterior draws
+  (rows = draws, columns = parameters). Relies on burn-in already being
+  discarded (see [T023]).
+- `log_post_kernel::AbstractVector{T}` — per-draw log posterior *kernel*
+  `log L(θ⁽ˢ⁾) + log π(θ⁽ˢ⁾)` (log likelihood + log prior). Any additive
+  constant in the likelihood cancels in the ratio and shifts the estimate by
+  that same constant, so the estimate is on the **same additive scale as the
+  SMC tempering-path estimator** (the Kalman log-likelihood carries its own
+  normalizing constant in both paths) — `:mh` and `:smc` marginal likelihoods,
+  and Bayes factors between them, are therefore comparable.
+
+Method. With posterior sample mean `θ̄` and covariance `Σ`, the weighting
+density `f` is a truncated multivariate normal on the `p`-probability ellipsoid
+`{θ : (θ−θ̄)'Σ⁻¹(θ−θ̄) ≤ χ²_{d,p}}`, normalized by the truncation mass `τ = p`:
+
+    log f(θ) = −log p − (d/2) log(2π) − ½ log|Σ| − ½ (θ−θ̄)'Σ⁻¹(θ−θ̄)   (inside)
+             = −∞                                                        (outside)
+
+and the estimator is
+
+    log p̂(y) = log S − logsumexp_s( log f(θ⁽ˢ⁾) − log_post_kernel(θ⁽ˢ⁾) ).
+
+Returns `NaN` (with a `@warn`) when the effective (finite-kernel) chain is too
+short (`S < 10·d`) or when no draw falls inside the truncation region.
+
+Reference: Geweke (1999), *Econometric Reviews* 18(1), 1–73.
+"""
+function _geweke_mhm(draws::AbstractMatrix{T}, log_post_kernel::AbstractVector{T};
+                     p::Real=0.5) where {T<:AbstractFloat}
+    d = size(draws, 2)
+    finite = findall(isfinite, log_post_kernel)
+    if length(finite) < 10 * d
+        @warn "Geweke MHM: effective post-burn-in chain too short " *
+              "(finite draws = $(length(finite)) < 10·d = $(10*d)); returning NaN. " *
+              "Increase n_draws or reduce burnin for a usable marginal likelihood."
+        return T(NaN)
+    end
+    D = Matrix{T}(draws[finite, :])
+    L = Vector{T}(log_post_kernel[finite])
+    S = length(finite)
+
+    # Posterior mean and (unbiased) covariance of the sampled draws.
+    θbar = vec(mean(D; dims=1))
+    Σ = d == 1 ? reshape([var(vec(D))], 1, 1) : cov(D)
+    Σsym = Symmetric(Matrix{T}(Σ))
+    Σinv = Matrix{T}(robust_inv(Σsym; silent=true))
+    logdetΣ = logdet_safe(Σsym)
+
+    # Truncated-normal weighting density constants; τ = p is the truncation mass.
+    thresh = T(quantile(Chisq(d), p))
+    log_const = -log(T(p)) - T(d) / 2 * log(T(2π)) - logdetΣ / 2
+
+    terms = fill(T(-Inf), S)
+    n_inside = 0
+    @inbounds for s in 1:S
+        δ = @view(D[s, :]) .- θbar
+        q = dot(δ, Σinv, δ)
+        if q <= thresh
+            terms[s] = (log_const - q / 2) - L[s]   # log f(θ) − log kernel(θ)
+            n_inside += 1
+        end
+    end
+    if n_inside == 0
+        @warn "Geweke MHM: no draws fell inside the p=$(p) truncation region; " *
+              "returning NaN (degenerate or extremely diffuse posterior sample)."
+        return T(NaN)
+    end
+    return log(T(S)) - _logsumexp(terms)
+end
+
+# =============================================================================
 # Internal: convert MH output to BayesianDSGE
 # =============================================================================
 
@@ -297,18 +378,12 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
                                         observables, measurement_error,
                                         solver, solver_kwargs)
 
-    # Approximate log marginal likelihood via harmonic mean estimator
-    # log p(Y) ≈ -log(1/n * sum(1/p(Y|θ_i))) = -log(mean(exp(-log_lik)))
-    # This is a simple approximation; SMC gives better estimates
-    finite_lp = filter(isfinite, log_posterior)
-    log_ml = if length(finite_lp) > 0
-        # Harmonic mean: 1/p(Y) ≈ E[1/L(θ)] under posterior
-        # Use log_posterior which includes prior, so extract log_lik estimate
-        # Simple approximation: max log posterior
-        T(maximum(finite_lp))
-    else
-        T(-Inf)
-    end
+    # Log marginal likelihood via Geweke (1999) modified harmonic mean (E-04 / #130).
+    # `log_posterior` stores the per-draw kernel log L(θ) + log π(θ), on the same
+    # additive scale as the SMC tempering-path estimator, so :mh and :smc marginal
+    # likelihoods (and Bayes factors between them) are comparable. Returns NaN + @warn
+    # when the post-burn-in chain is too short.
+    log_ml = _geweke_mhm(draws, log_posterior)
 
     BayesianDSGE{T}(
         draws, log_posterior, param_names, prior,
@@ -409,8 +484,16 @@ end
 
 Return the log marginal likelihood (model evidence) from Bayesian estimation.
 
-For SMC methods, this is the normalizing constant estimate from the
-adaptive tempering schedule. For RWMH, this is an approximation.
+For SMC methods, this is the normalizing-constant estimate from the adaptive
+tempering schedule (preferred when available). For RWMH (`:mh`), it is the
+Geweke (1999) modified harmonic mean (MHM) estimate computed from the
+post-burn-in draws — the Dynare standard — on the same additive scale as the
+SMC estimate. The MHM returns `NaN` (with a warning) when the chain is too
+short to form a usable estimate.
+
+# References
+- Geweke, J. (1999). Using simulation methods for Bayesian econometric models.
+  *Econometric Reviews*, 18(1), 1-73.
 """
 function marginal_likelihood(result::BayesianDSGE)
     return result.log_marginal_likelihood
@@ -424,6 +507,10 @@ Compute the log Bayes factor comparing model 1 to model 2:
 
 A positive value favors model 1; negative favors model 2.
 Following Kass & Raftery (1995), `2 * log BF > 6` is strong evidence.
+
+Both marginal likelihoods must be on the same additive scale: SMC (tempering
+path) and `:mh` (Geweke MHM) estimates are comparable by construction, but
+compare estimators consistently and prefer SMC when available.
 
 # References
 - Kass, R. E. & Raftery, A. E. (1995). Bayes Factors.

--- a/src/dsge/bayes_types.jl
+++ b/src/dsge/bayes_types.jl
@@ -547,6 +547,9 @@ Fields:
 - `state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}}` — state space at posterior mode
 - `n_failed_draws::Int` — number of likelihood evaluations that failed during sampling
 - `n_lik_evals::Int` — total number of likelihood evaluations during sampling
+- `solved_at::Symbol` — which θ the stored `solution`/`state_space` was built at
+  (`:posterior_mean` normally; `:highest_posterior_draw` when the posterior-mean solve
+  failed and the container was built at the highest-posterior draw instead)
 """
 struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     theta_draws::Matrix{T}
@@ -563,30 +566,35 @@ struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}, ProjectionStateSpace{T}}
     n_failed_draws::Int
     n_lik_evals::Int
+    solved_at::Symbol
 
     function BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
                               log_marginal_likelihood, method, acceptance_rate,
                               ess_history, phi_schedule, spec, solution,
-                              state_space, n_failed_draws, n_lik_evals) where {T<:AbstractFloat}
+                              state_space, n_failed_draws, n_lik_evals,
+                              solved_at) where {T<:AbstractFloat}
         n_draws, n_params = size(theta_draws)
         @assert length(log_posterior) == n_draws "log_posterior length must match n_draws"
         @assert length(param_names) == n_params "param_names length must match n_params"
         @assert method in (:smc, :rwmh, :csmc, :smc2, :importance) "unknown method: $method"
+        @assert solved_at in (:posterior_mean, :highest_posterior_draw) "solved_at must be :posterior_mean or :highest_posterior_draw"
         new{T}(theta_draws, log_posterior, param_names, priors,
                log_marginal_likelihood, method, acceptance_rate,
                ess_history, phi_schedule, spec, solution, state_space,
-               n_failed_draws, n_lik_evals)
+               n_failed_draws, n_lik_evals, solved_at)
     end
 end
 
-# Backward-compatible 12-arg constructor (failure counters default to 0).
+# Backward-compatible 12-arg constructor (failure counters default to 0, solved_at to
+# :posterior_mean); keeps direct 12-arg construction sites (e.g. HD tests) compiling.
 BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
                 log_marginal_likelihood, method, acceptance_rate,
                 ess_history, phi_schedule, spec, solution,
                 state_space) where {T<:AbstractFloat} =
     BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
                     log_marginal_likelihood, method, acceptance_rate,
-                    ess_history, phi_schedule, spec, solution, state_space, 0, 0)
+                    ess_history, phi_schedule, spec, solution, state_space,
+                    0, 0, :posterior_mean)
 
 # =============================================================================
 # BayesianDSGESimulation — posterior predictive simulation with credible bands

--- a/src/dsge/bayes_types.jl
+++ b/src/dsge/bayes_types.jl
@@ -9,6 +9,21 @@ Type definitions for Bayesian DSGE estimation — priors, state spaces, particle
 workspace, SMC state, and posterior result container.
 """
 
+"""
+    StochasticSingularityError <: Exception
+
+Raised when a DSGE observation equation is stochastically singular — more observables
+than structural shocks (`n_obs > n_shocks`) with no measurement error — so the
+model-implied observation covariance is singular and the likelihood is ill-defined.
+Distinct from a per-θ numeric failure: it is a model/data misspecification the user
+must fix (add measurement error or reduce observables), so it is NOT swallowed to
+-Inf by the likelihood closures (it is not in `_benign_solve_error`).
+"""
+struct StochasticSingularityError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::StochasticSingularityError) = print(io, "StochasticSingularityError: ", e.msg)
+
 # =============================================================================
 # DSGEPrior — prior specification for Bayesian DSGE
 # =============================================================================

--- a/src/dsge/bayes_types.jl
+++ b/src/dsge/bayes_types.jl
@@ -485,6 +485,8 @@ Fields:
 - `log_marginal_likelihood::T` — cumulative log marginal likelihood estimate
 - `pf_workspace_pool::Vector{PFWorkspace{T}}` — reusable PF workspace pool
 - `proposal_cov::Matrix{T}` — MCMC mutation proposal covariance
+- `n_lik_failures::Int` — number of likelihood evaluations that failed (returned -Inf)
+- `n_lik_evals::Int` — total number of likelihood evaluations
 """
 mutable struct SMCState{T<:AbstractFloat}
     theta_particles::Matrix{T}
@@ -497,7 +499,14 @@ mutable struct SMCState{T<:AbstractFloat}
     log_marginal_likelihood::T
     pf_workspace_pool::Vector{PFWorkspace{T}}
     proposal_cov::Matrix{T}
+    n_lik_failures::Int
+    n_lik_evals::Int
 end
+
+# Backward-compatible 10-arg constructor (failure counters default to 0); the samplers
+# build with this form and set n_lik_failures / n_lik_evals post-hoc.
+SMCState{T}(tp, lw, ll, lp, phi, ess, ar, lml, pool, pcov) where {T<:AbstractFloat} =
+    SMCState{T}(tp, lw, ll, lp, phi, ess, ar, lml, pool, pcov, 0, 0)
 
 # =============================================================================
 # BayesianDSGE — posterior result container
@@ -521,6 +530,8 @@ Fields:
 - `spec::DSGESpec{T}` — model specification
 - `solution::Union{DSGESolution{T}, PerturbationSolution{T}}` — solution at posterior mode
 - `state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}}` — state space at posterior mode
+- `n_failed_draws::Int` — number of likelihood evaluations that failed during sampling
+- `n_lik_evals::Int` — total number of likelihood evaluations during sampling
 """
 struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     theta_draws::Matrix{T}
@@ -535,20 +546,32 @@ struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     spec::DSGESpec{T}
     solution::Union{DSGESolution{T}, PerturbationSolution{T}, ProjectionSolution{T}}
     state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}, ProjectionStateSpace{T}}
+    n_failed_draws::Int
+    n_lik_evals::Int
 
     function BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
                               log_marginal_likelihood, method, acceptance_rate,
                               ess_history, phi_schedule, spec, solution,
-                              state_space) where {T<:AbstractFloat}
+                              state_space, n_failed_draws, n_lik_evals) where {T<:AbstractFloat}
         n_draws, n_params = size(theta_draws)
         @assert length(log_posterior) == n_draws "log_posterior length must match n_draws"
         @assert length(param_names) == n_params "param_names length must match n_params"
         @assert method in (:smc, :rwmh, :csmc, :smc2, :importance) "unknown method: $method"
         new{T}(theta_draws, log_posterior, param_names, priors,
                log_marginal_likelihood, method, acceptance_rate,
-               ess_history, phi_schedule, spec, solution, state_space)
+               ess_history, phi_schedule, spec, solution, state_space,
+               n_failed_draws, n_lik_evals)
     end
 end
+
+# Backward-compatible 12-arg constructor (failure counters default to 0).
+BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
+                log_marginal_likelihood, method, acceptance_rate,
+                ess_history, phi_schedule, spec, solution,
+                state_space) where {T<:AbstractFloat} =
+    BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
+                    log_marginal_likelihood, method, acceptance_rate,
+                    ess_history, phi_schedule, spec, solution, state_space, 0, 0)
 
 # =============================================================================
 # BayesianDSGESimulation — posterior predictive simulation with credible bands

--- a/src/dsge/estimation.jl
+++ b/src/dsge/estimation.jl
@@ -42,6 +42,7 @@ function estimate_dsge(spec::DSGESpec{T}, data::AbstractMatrix,
                         target_irfs::Union{Nothing,ImpulseResponse}=nothing,
                         var_lags::Int=4, irf_horizon::Int=20,
                         weighting::Symbol=:two_step,
+                        n_boot::Int=200,
                         n_lags_instruments::Int=4,
                         sim_ratio::Int=5, burn::Int=100,
                         moments_fn::Function=d -> autocovariance_moments(d; lags=1),
@@ -60,7 +61,8 @@ function estimate_dsge(spec::DSGESpec{T}, data::AbstractMatrix,
                                        target_irfs=target_irfs,
                                        var_lags=var_lags,
                                        irf_horizon=irf_horizon,
-                                       weighting=weighting)
+                                       weighting=weighting,
+                                       n_boot=n_boot)
     elseif method == :euler_gmm
         return _estimate_euler_gmm(spec, data_T, param_names;
                                     n_lags=n_lags_instruments,
@@ -100,21 +102,40 @@ end
 """
     _estimate_irf_matching(spec, data, param_names; ...) -> DSGEEstimation
 
-Internal: IRF matching GMM estimation.
+Internal: IRF matching minimum-distance (GMM) estimation, Christiano, Eichenbaum &
+Evans (2005). Matches model-implied IRFs `Ψ_model(θ)` to empirical VAR-Cholesky IRFs
+`Ψ_VAR` by minimizing `g(θ)'W g(θ)` where `g(θ) = Ψ_model(θ) − Ψ_VAR`.
 
-Matches model-implied IRFs to empirical VAR IRFs by minimizing the distance
-under a GMM weighting matrix.
+Inference uses the CEE sandwich with `Ω = Var(Ψ_VAR)`, the bootstrap covariance of
+the empirical VAR IRF targets:
+
+    Var(θ̂) = (G'WG)⁻¹ G'W Ω W G (G'WG)⁻¹,   G = ∂Ψ_model/∂θ'
+
+Under efficient weighting `W = Ω⁻¹` this collapses to `(G'Ω⁻¹G)⁻¹` and the
+overidentification statistic `J = g'Ω⁻¹g ~ χ²(dim g − dim θ)`. Under diagonal
+(CEE `W = diag(Ω)⁻¹`) or identity weighting no χ² J is reported.
+
+`weighting`: `:two_step`/`:efficient`/`:optimal` → `W = Ω⁻¹` (χ² J reported);
+`:diagonal`/`:cee` → `W = diag(Ω)⁻¹`; `:identity` → `W = I`. If no valid bootstrap
+draws are available, falls back to identity weighting with a warning (SEs not CEE-valid).
+
+Shock units: both the model IRF (whose impact matrix embeds the structural-shock
+standard deviations via the σ parameters) and the VAR Cholesky target use 1-s.d.
+shock scaling, so for well-scaled models they align.
 """
 function _estimate_irf_matching(spec::DSGESpec{T}, data::Matrix{T},
                                  param_names::Vector{Symbol};
                                  target_irfs=nothing, var_lags=4,
-                                 irf_horizon=20, weighting=:two_step) where {T}
+                                 irf_horizon=20, weighting=:two_step,
+                                 n_boot::Int=200) where {T}
     n_est = length(param_names)
 
-    # Step 1: Compute target IRFs from VAR if not provided
+    # Step 1: Compute target IRFs from VAR if not provided (with bootstrap draws so
+    # the sampling covariance Ω of the empirical IRF targets can be estimated).
     if target_irfs === nothing
         var_model = estimate_var(data, var_lags)
-        target_irfs = irf(var_model, irf_horizon; method=:cholesky)
+        target_irfs = irf(var_model, irf_horizon; method=:cholesky,
+                          ci_type=:bootstrap, reps=n_boot)
     end
     target_vec = vec(target_irfs.values)
     n_moments = length(target_vec)
@@ -146,9 +167,54 @@ function _estimate_irf_matching(spec::DSGESpec{T}, data::Matrix{T},
         end
     end
 
-    # IRF matching is a minimum-distance estimator: min_θ g(θ)' W g(θ)
-    # Use identity weighting matrix (standard for IRF matching)
-    W = Matrix{T}(I, n_moments, n_moments)
+    # IRF matching is a minimum-distance estimator: min_θ g(θ)' W g(θ).
+    # Estimate Ω = Var(Ψ_VAR), the bootstrap covariance of the empirical IRF targets.
+    draws = target_irfs._draws
+    if draws === nothing
+        vm = estimate_var(data, var_lags)
+        draws = irf(vm, irf_horizon; method=:cholesky,
+                    ci_type=:bootstrap, reps=n_boot)._draws
+    end
+
+    identity_fallback = false
+    Omega = if draws !== nothing && size(draws, 1) >= 2 &&
+               prod(size(draws)[2:end]) == n_moments
+        R = size(draws, 1)
+        D = Matrix{T}(undef, n_moments, R)
+        for r in 1:R
+            D[:, r] = vec(@view draws[r, :, :, :])
+        end
+        cov(D; dims=2)                       # columns = R bootstrap observations
+    else
+        identity_fallback = true
+        @warn "IRF-matching: no valid bootstrap draws for target IRFs — falling back " *
+              "to identity weighting; SEs are not CEE-valid."
+        Matrix{T}(I, n_moments, n_moments)
+    end
+
+    # Near-singular Ω is common at long horizons: warn (efficient weighting unstable).
+    if !identity_fallback
+        sv = svdvals(Omega)
+        if sv[end] < sqrt(eps(T)) * sv[1]
+            @warn "IRF-matching: target IRF covariance Ω is near-singular (common at " *
+                  "long horizons); efficient weighting is unstable — consider weighting=:diagonal."
+        end
+    end
+
+    # Resolve the weighting matrix W and whether a χ² J is meaningful.
+    W, report_J = if identity_fallback
+        (Matrix{T}(I, n_moments, n_moments), false)
+    elseif weighting in (:efficient, :optimal, :two_step)
+        (robust_inv(Omega), true)
+    elseif weighting in (:diagonal, :cee)
+        (Matrix{T}(Diagonal(one(T) ./ diag(Omega))), false)
+    elseif weighting === :identity
+        (Matrix{T}(I, n_moments, n_moments), false)
+    else
+        throw(ArgumentError("IRF-matching weighting must be :efficient/:optimal/:two_step, " *
+                            ":diagonal/:cee, or :identity; got :$weighting"))
+    end
+
     result = minimize_gmm(
         (theta, _data) -> reshape(irf_distance(theta), 1, :),
         theta0, data, W; max_iter=100, tol=T(1e-8)
@@ -156,25 +222,26 @@ function _estimate_irf_matching(spec::DSGESpec{T}, data::Matrix{T},
     theta_hat = result.theta
     converged = result.converged
 
-    # Compute vcov via numerical Hessian of the objective
-    # Q(θ) = g(θ)'g(θ), so ∂²Q/∂θ² gives the curvature
+    # CEE minimum-distance sandwich covariance:
+    #   Var(θ̂) = (G'WG)⁻¹ G'W Ω W G (G'WG)⁻¹,  G = ∂g/∂θ = ∂Ψ_model/∂θ'
+    # (No 1/T_obs — Ω already carries the sampling scale of the targets.)
     g_hat = irf_distance(theta_hat)
-    dg = numerical_gradient(irf_distance, theta_hat)  # n_moments x n_est
+    dg = numerical_gradient(irf_distance, theta_hat)  # n_moments x n_est (this is G)
 
-    # For minimum-distance with identity W:
-    # V_θ = (G'G)^{-1} where G = ∂g/∂θ evaluated at θ_hat
     bread = dg' * W * dg
     bread_inv = robust_inv(bread)
-    T_obs = size(data, 1)
-    vcov_hat = bread_inv / T(T_obs)
+    meat = dg' * W * Omega * W * dg
+    vcov_hat = bread_inv * meat * bread_inv
+    vcov_hat = (vcov_hat + vcov_hat') / 2
 
-    # J-statistic (overidentification test)
-    J_stat, J_pvalue = if n_moments > n_est
-        J = T(T_obs) * (g_hat' * W * g_hat)
+    # Overidentification test: valid χ² only under efficient weighting W = Ω⁻¹.
+    J_stat, J_pvalue = if report_J && n_moments > n_est
+        Omega_inv = robust_inv(Omega)
+        J = g_hat' * Omega_inv * g_hat
         df = n_moments - n_est
-        (J, one(T) - cdf(Chisq(df), J))
+        (T(J), T(one(T) - cdf(Chisq(df), J)))
     else
-        (zero(T), one(T))
+        (T(NaN), T(NaN))
     end
 
     # Build solution at estimated parameters

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -147,9 +147,19 @@ function _build_ha_observation_equation(sol::HADSGESolution{T},
         end
     end
 
-    # H: measurement error covariance
+    # H: measurement error covariance. Default is ZERO; a nonzero default would mask
+    # stochastic singularity (the reduced HA system has size(linear.impact,2) aggregate
+    # shocks — architecturally 1 for SSJ/Reiter).
     if measurement_error === nothing
-        H = T(1e-4) * Matrix{T}(I, n_obs, n_obs)
+        H = zeros(T, n_obs, n_obs)
+        n_shocks = size(linear.impact, 2)
+        if n_obs > n_shocks
+            throw(StochasticSingularityError(
+                "$n_obs observables exceed $n_shocks aggregate structural shock(s) in the " *
+                "reduced HA system; the model-implied observation covariance is singular and " *
+                "the likelihood is ill-defined. Add measurement error (measurement_error=:auto " *
+                "or a vector of SDs) or reduce the number of observables."))
+        end
     else
         me = Vector{T}(measurement_error)
         length(me) == n_obs || throw(ArgumentError(
@@ -264,7 +274,10 @@ and the Kalman filter is evaluated on the reduced linear system. This is the
 - `observables::Vector{Symbol}` — which aggregate variables are observed (e.g., `[:K]`)
 - `n_draws::Int=5000` — total MH draws (including burnin)
 - `burnin::Int=1000` — number of burnin draws to discard
-- `measurement_error::Union{Nothing,Vector{<:Real}}=nothing` — measurement error SDs
+- `measurement_error::Union{Nothing,Symbol,Vector{<:Real}}=nothing` — measurement error SDs;
+  `nothing` means zero ME (requires `n_obs ≤ n_shocks`, else a `StochasticSingularityError`
+  is thrown on the first likelihood evaluation); `:auto` adds per-observable ME at 10% of
+  each series' variance with a warning
 - `ha_method::Symbol=:ssj` — HA solution method (`:ssj` or `:reiter`)
 - `ha_kwargs::NamedTuple=(T_horizon=50, n_reduced=15)` — HA solver options
 - `proposal_scale::Float64=0.01` — initial RWMH proposal scale (σ² for proposal cov)
@@ -290,7 +303,7 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
                               observables::Vector{Symbol}=Symbol[],
                               n_draws::Int=5000,
                               burnin::Int=1000,
-                              measurement_error::Union{Nothing,Vector{<:Real}}=nothing,
+                              measurement_error::Union{Nothing,Symbol,Vector{<:Real}}=nothing,
                               ha_method::Symbol=:ssj,
                               ha_kwargs::NamedTuple=(T_horizon=50, n_reduced=15),
                               proposal_scale::Float64=0.01,
@@ -319,6 +332,12 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
     # Public convention is T×n; the Kalman filter on the reduced system expects
     # n_obs × T_obs internally.
     data_mat = _orient_data(data, n_obs, T)
+
+    # Resolve :auto measurement error against data variance (per-observable). (#141/T042)
+    # The stochastic-singularity error itself is raised by _build_ha_observation_equation
+    # and rethrown from ll_fn's narrow catch on the first evaluation (HA has no cheap
+    # pre-solve shock count).
+    measurement_error = _resolve_measurement_error(measurement_error, data_mat, observables)
 
     # ── 4. Resolve theta0 against sorted prior keys ──────────────────────
     # Dict/NamedTuple resolved by name (order-independent); a positional vector must be

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -437,9 +437,11 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
         Z, d, H = _build_ha_observation_equation(sol_mean, observables, measurement_error)
         ss_result = _build_state_space(linear_sol, Z, d, H)
 
-        # Approximate log marginal likelihood via max log posterior
-        finite_lp = filter(isfinite, post_log_posterior)
-        log_ml = isempty(finite_lp) ? T(-Inf) : T(maximum(finite_lp))
+        # Log marginal likelihood via Geweke (1999) modified harmonic mean (E-04 / #130).
+        # `post_log_posterior` stores the per-draw kernel log L(θ) + log π(θ); the MHM is
+        # on the same additive scale as the SMC estimator. Returns NaN + @warn on a chain
+        # too short to build the truncated-normal weighting density.
+        log_ml = _geweke_mhm(post_draws, post_log_posterior)
 
         return BayesianDSGE{T}(
             post_draws, post_log_posterior, param_names, prior,

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -247,9 +247,64 @@ function _build_ha_likelihood_fn(spec::HADSGESpec{T}, param_names::Vector{Symbol
     return ll_fn
 end
 
+"""
+    _build_ha_result_solution(spec, param_names, post_draws, post_log_posterior,
+                              observables, measurement_error, ha_method, ha_kwargs)
+        -> (linear_sol, ss_result, solved_at, theta_used)
+
+Build the HA result-container solution at the posterior mean; if that fails to produce a
+valid (finite) reduced solution, fall back to the **highest-posterior draw** — marked as
+such (`solved_at`), never the old silent substitution of the ORIGINAL pre-estimation spec
+(E-25 / #149). The validity gate (`isfinite` on the reduced `G1`/`impact`) is intentionally
+looser than the likelihood's determinacy gate so a previously-accepted posterior-mean
+solution is not newly demoted to the fallback; it also rejects a NaN-filled solution
+returned without throwing. Errors loudly if neither candidate solves. Aligns the
+`solved_at` convention with the aggregate fallback ([T044]/#143).
+"""
+function _build_ha_result_solution(spec::HADSGESpec{T}, param_names::Vector{Symbol},
+        post_draws::AbstractMatrix{<:Real}, post_log_posterior::AbstractVector{<:Real},
+        observables::Vector{Symbol}, measurement_error, ha_method::Symbol,
+        ha_kwargs::NamedTuple) where {T<:AbstractFloat}
+    theta_mean = Vector{T}(vec(mean(post_draws; dims=1)))
+    best_idx = argmax(post_log_posterior)
+    theta_hpd = Vector{T}(post_draws[best_idx, :])
+    candidates = ((theta_mean, :posterior_mean), (theta_hpd, :highest_posterior_draw))
+    for (theta_c, tag) in candidates
+        # A bad-θ (e.g. NaN-mean) solve may THROW or return a NaN-filled solution; both are
+        # rejected. The final error() below guarantees no silent wrong result.
+        sol_c = try
+            solve(_update_ha_params(spec, param_names, theta_c); method=ha_method, ha_kwargs...)
+        catch
+            nothing
+        end
+        if sol_c isa HADSGESolution &&
+           all(isfinite, sol_c.linear_solution.G1) &&
+           all(isfinite, sol_c.linear_solution.impact)
+            if tag === :highest_posterior_draw
+                @warn "HA Bayesian estimation: posterior-mean solve failed; result container " *
+                      "built at the highest-posterior draw (θ index $best_idx). IRFs/FEVD " *
+                      "reflect that draw, not the posterior mean — see result.solved_at."
+            end
+            linear_sol = sol_c.linear_solution
+            Z, d, H = _build_ha_observation_equation(sol_c, observables, measurement_error)
+            ss_result = _build_state_space(linear_sol, Z, d, H)
+            return linear_sol, ss_result, tag, theta_c
+        end
+    end
+    error("HA Bayesian estimation: neither the posterior mean nor the highest-posterior " *
+          "draw produced a valid (finite) reduced solution — check the prior support / " *
+          "model determinacy in that region, and that :ssj or :reiter was used " *
+          "(KrusellSmithSolution is unsupported).")
+end
+
 # =============================================================================
 # estimate_dsge_bayes(::HADSGESpec, ...) — main entry point
 # =============================================================================
+
+# Default sequence-space (SSJ) truncation length for HA Bayesian estimation. Auclert,
+# Bardóczy, Rognlie & Straub (2021) use 300; too-small values truncate persistent HA
+# Jacobians and bias the Kalman likelihood (E-24 / #148).
+const _HA_DEFAULT_T_HORIZON = 300
 
 """
     estimate_dsge_bayes(spec::HADSGESpec{T}, data, θ0; priors, kwargs...) → BayesianDSGE{T}
@@ -279,7 +334,13 @@ and the Kalman filter is evaluated on the reduced linear system. This is the
   is thrown on the first likelihood evaluation); `:auto` adds per-observable ME at 10% of
   each series' variance with a warning
 - `ha_method::Symbol=:ssj` — HA solution method (`:ssj` or `:reiter`)
-- `ha_kwargs::NamedTuple=(T_horizon=50, n_reduced=15)` — HA solver options
+- `ha_kwargs::NamedTuple=(T_horizon=300, n_reduced=15)` — HA solver options. `T_horizon`
+  sets the sequence-space (SSJ) truncation length: the HA Jacobians must decay before this
+  horizon or the model-implied autocovariances (and hence the Kalman likelihood) are biased.
+  The default of 300 follows Auclert, Bardóczy, Rognlie & Straub (2021); too-small values
+  (e.g. 50) truncate persistent HA dynamics prematurely, while larger horizons cost more
+  (Jacobian construction scales with the horizon). Only the default changes — `T_horizon`
+  remains user-overridable.
 - `proposal_scale::Float64=0.01` — initial RWMH proposal scale (σ² for proposal cov)
 - `adapt_interval::Int=100` — adapt proposal covariance every N draws
 - `rng::AbstractRNG=Random.default_rng()` — random number generator
@@ -305,7 +366,7 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
                               burnin::Int=1000,
                               measurement_error::Union{Nothing,Symbol,Vector{<:Real}}=nothing,
                               ha_method::Symbol=:ssj,
-                              ha_kwargs::NamedTuple=(T_horizon=50, n_reduced=15),
+                              ha_kwargs::NamedTuple=(T_horizon=_HA_DEFAULT_T_HORIZON, n_reduced=15),
                               proposal_scale::Float64=0.01,
                               adapt_interval::Int=100,
                               rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
@@ -465,40 +526,24 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
     post_draws = draws[burnin+1:end, :]
     post_log_posterior = log_posterior[burnin+1:end]
 
-    # ── 8. Build solution at posterior mean ───────────────────────────────
-    theta_mean = vec(mean(post_draws; dims=1))
-    new_spec_mean = _update_ha_params(spec, param_names, theta_mean)
+    # ── 8. Build solution at posterior mean (else the highest-posterior draw, marked) ──
+    # No longer silently re-solves the ORIGINAL spec on failure (the E-25/#149 bug); the
+    # helper marks which θ the stored solution was built at and errors loudly if none solve.
+    linear_sol, ss_result, solved_at, _theta_used = _build_ha_result_solution(
+        spec, param_names, post_draws, post_log_posterior,
+        observables, measurement_error, ha_method, ha_kwargs)
 
-    # Solve at posterior mean for the result container
-    sol_mean = try
-        solve(new_spec_mean; method=ha_method, ha_kwargs...)
-    catch
-        # Fallback: solve at initial theta
-        solve(spec; method=ha_method, ha_kwargs...)
-    end
+    # Log marginal likelihood via Geweke (1999) modified harmonic mean (E-04 / #130).
+    # `post_log_posterior` stores the per-draw kernel log L(θ) + log π(θ); the MHM is on
+    # the same additive scale as the SMC estimator. Returns NaN + @warn on a chain too
+    # short to build the truncated-normal weighting density.
+    log_ml = _geweke_mhm(post_draws, post_log_posterior)
 
-    # Extract the linear solution and build state space
-    if sol_mean isa HADSGESolution
-        linear_sol = sol_mean.linear_solution
-        Z, d, H = _build_ha_observation_equation(sol_mean, observables, measurement_error)
-        ss_result = _build_state_space(linear_sol, Z, d, H)
-
-        # Log marginal likelihood via Geweke (1999) modified harmonic mean (E-04 / #130).
-        # `post_log_posterior` stores the per-draw kernel log L(θ) + log π(θ); the MHM is
-        # on the same additive scale as the SMC estimator. Returns NaN + @warn on a chain
-        # too short to build the truncated-normal weighting density.
-        log_ml = _geweke_mhm(post_draws, post_log_posterior)
-
-        return BayesianDSGE{T}(
-            post_draws, post_log_posterior, param_names, prior,
-            log_ml, :rwmh, acceptance_rate,
-            T[], T[],  # no ESS history or phi schedule for MH
-            linear_sol.spec, linear_sol, ss_result,
-            lik_failures[], lik_evals[], :posterior_mean  # solved_at refined in [T050]/#149
-        )
-    else
-        # KrusellSmithSolution or other — build a minimal DSGESolution
-        error("Bayesian estimation requires :ssj or :reiter method " *
-              "(produces HADSGESolution with a linear system for Kalman filter)")
-    end
+    return BayesianDSGE{T}(
+        post_draws, post_log_posterior, param_names, prior,
+        log_ml, :rwmh, acceptance_rate,
+        T[], T[],  # no ESS history or phi schedule for MH
+        linear_sol.spec, linear_sol, ss_result,
+        lik_failures[], lik_evals[], solved_at
+    )
 end

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -238,8 +238,11 @@ and the Kalman filter is evaluated on the reduced linear system. This is the
 
 # Arguments
 - `spec::HADSGESpec{T}` — HA-DSGE model specification
-- `data::AbstractMatrix` — observed aggregate data (T_obs × n_obs or n_obs × T_obs)
-- `θ0::AbstractVector{<:Real}` — initial parameter guess (length matches priors)
+- `data::AbstractMatrix` — observed aggregate data in `T×n` (time in rows); orientation is
+  resolved by matching a dimension to the number of observables (`n×T` transposed internally).
+- `θ0` — initial parameter guess. Preferred: a `Dict{Symbol}`/`NamedTuple` keyed by parameter
+  name (order-independent). A positional `AbstractVector` must be in sorted (alphabetical)
+  prior-key order and length-matched, else an informative `ArgumentError` is thrown.
 
 # Keywords
 - `priors::Dict{Symbol,<:Distribution}` — prior distributions keyed by parameter name
@@ -266,7 +269,8 @@ the posterior-mean HA solution.
   *Journal of Applied Econometrics*, 29(7), 1073-1098.
 """
 function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
-                              theta0::AbstractVector{<:Real};
+                              theta0::Union{AbstractVector{<:Real},
+                                            AbstractDict{Symbol,<:Real},NamedTuple};
                               priors::Dict{Symbol,<:Distribution},
                               observables::Vector{Symbol}=Symbol[],
                               n_draws::Int=5000,
@@ -296,20 +300,17 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
     end
     n_obs = length(observables)
 
-    # ── 3. Data handling: ensure n_obs × T_obs format ────────────────────
-    data_mat = Matrix{T}(data)
-    nrows, ncols = size(data_mat)
-    if nrows != n_obs && ncols == n_obs
-        data_mat = Matrix{T}(data_mat')
-    elseif nrows != n_obs && ncols != n_obs
-        if nrows > ncols
-            data_mat = Matrix{T}(data_mat')
-        end
-    end
+    # ── 3. Data handling: resolve orientation by matching n_obs (E-18 / #142) ─
+    # Public convention is T×n; the Kalman filter on the reduced system expects
+    # n_obs × T_obs internally.
+    data_mat = _orient_data(data, n_obs, T)
 
-    # ── 4. Sort theta0 to match prior ordering ───────────────────────────
+    # ── 4. Resolve theta0 against sorted prior keys ──────────────────────
+    # Dict/NamedTuple resolved by name (order-independent); a positional vector must be
+    # in sorted prior-key order and is length-validated (E-12 / H-12 / #136). (The old
+    # comment claimed a reordering that never happened — it only cast T.(theta0).)
     n_params = length(param_names)
-    theta0_sorted = T.(theta0)
+    theta0_sorted = _resolve_theta0(theta0, param_names, T)
 
     # ── 5. Build HA likelihood function ──────────────────────────────────
     ll_fn = _build_ha_likelihood_fn(spec, param_names, data_mat, observables,

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -351,6 +351,7 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
     proposal_L = cholesky(Hermitian(proposal_cov)).L
 
     total_accepted = 0
+    window_accepted = 0
 
     for draw in 1:n_draws
         # Propose
@@ -373,6 +374,7 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
                     ll_current = ll_star
                     lp_current = lp_star
                     total_accepted += 1
+                    window_accepted += 1
                 end
             end
         end
@@ -381,35 +383,41 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
         draws[draw, :] = theta_current
         log_posterior[draw] = ll_current + lp_current
 
-        # Adapt proposal covariance
-        if draw % adapt_interval == 0 && draw >= 2 * adapt_interval
-            recent_start = max(1, draw - 5 * adapt_interval)
-            recent_draws = draws[recent_start:draw, :]
+        # Adapt proposal covariance and scale — ONLY during burn-in (frozen after), so the
+        # burn-in-discarded retained chain targets the exact posterior (Roberts & Rosenthal 2007).
+        if draw <= burnin && draw % adapt_interval == 0
+            # Trailing-window acceptance signal (not the stale cumulative rate).
+            window_acc = T(window_accepted) / T(adapt_interval)
+            window_accepted = 0
 
-            if size(recent_draws, 1) > n_params + 1
-                sample_cov = cov(recent_draws)
-                sample_cov = (sample_cov + sample_cov') / 2
-                for i in 1:n_params
-                    if sample_cov[i, i] < T(1e-10)
-                        sample_cov[i, i] = T(1e-10)
+            if draw >= 2 * adapt_interval
+                recent_start = max(1, draw - 5 * adapt_interval)
+                recent_draws = draws[recent_start:draw, :]
+
+                if size(recent_draws, 1) > n_params + 1
+                    sample_cov = cov(recent_draws)
+                    sample_cov = (sample_cov + sample_cov') / 2
+                    for i in 1:n_params
+                        if sample_cov[i, i] < T(1e-10)
+                            sample_cov[i, i] = T(1e-10)
+                        end
+                    end
+
+                    proposal_cov = c2 * sample_cov
+                    proposal_L = try
+                        cholesky(Hermitian(proposal_cov)).L
+                    catch
+                        proposal_cov += T(1e-6) * I
+                        cholesky(Hermitian(proposal_cov)).L
                     end
                 end
 
-                proposal_cov = c2 * sample_cov
-                proposal_L = try
-                    cholesky(Hermitian(proposal_cov)).L
-                catch
-                    proposal_cov += T(1e-6) * I
-                    cholesky(Hermitian(proposal_cov)).L
+                # Adapt scale factor targeting ~23.4% acceptance (trailing window)
+                if window_acc > T(0.30)
+                    scale_factor *= T(1.1)
+                elseif window_acc < T(0.15)
+                    scale_factor *= T(0.9)
                 end
-            end
-
-            # Adapt scale factor targeting ~23.4% acceptance
-            recent_acc = total_accepted / draw
-            if recent_acc > T(0.30)
-                scale_factor *= T(1.1)
-            elseif recent_acc < T(0.15)
-                scale_factor *= T(0.9)
             end
         end
     end

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -182,10 +182,13 @@ Returns `-Inf` on any failure (non-convergence, singular matrices, etc.).
 function _build_ha_likelihood_fn(spec::HADSGESpec{T}, param_names::Vector{Symbol},
                                   data::AbstractMatrix, observables::Vector{Symbol},
                                   measurement_error, ha_method::Symbol,
-                                  ha_kwargs::NamedTuple) where {T<:AbstractFloat}
+                                  ha_kwargs::NamedTuple;
+                                  failures::Threads.Atomic{Int}=Threads.Atomic{Int}(0),
+                                  evals::Threads.Atomic{Int}=Threads.Atomic{Int}(0)) where {T<:AbstractFloat}
     data_mat = Matrix{T}(data)
 
     function ll_fn(theta::Vector{T})
+        Threads.atomic_add!(evals, 1)
         try
             # Update parameters in both aggregate_spec and het_params
             new_spec = _update_ha_params(spec, param_names, theta)
@@ -195,15 +198,18 @@ function _build_ha_likelihood_fn(spec::HADSGESpec{T}, param_names::Vector{Symbol
 
             # Validate solution
             if !(sol isa HADSGESolution)
+                Threads.atomic_add!(failures, 1)
                 return T(-Inf)
             end
             if !is_determined(sol)
+                Threads.atomic_add!(failures, 1)
                 return T(-Inf)
             end
 
             # Extract the reduced linear system
             linear_sol = sol.linear_solution
             if linear_sol === nothing
+                Threads.atomic_add!(failures, 1)
                 return T(-Inf)
             end
 
@@ -213,9 +219,18 @@ function _build_ha_likelihood_fn(spec::HADSGESpec{T}, param_names::Vector{Symbol
 
             # Evaluate Kalman log-likelihood
             ll = _kalman_loglikelihood(ss, data_mat)
-            return isfinite(ll) ? ll : T(-Inf)
-        catch
-            return T(-Inf)
+            if isfinite(ll)
+                return ll
+            else
+                Threads.atomic_add!(failures, 1)
+                return T(-Inf)
+            end
+        catch e
+            if _benign_solve_error(e)
+                Threads.atomic_add!(failures, 1)
+                return T(-Inf)
+            end
+            rethrow(e)
         end
     end
 
@@ -312,9 +327,12 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
     n_params = length(param_names)
     theta0_sorted = _resolve_theta0(theta0, param_names, T)
 
-    # ── 5. Build HA likelihood function ──────────────────────────────────
+    # ── 5. Build HA likelihood function (tracking failed/total likelihood evals) ──
+    lik_failures = Threads.Atomic{Int}(0)
+    lik_evals = Threads.Atomic{Int}(0)
     ll_fn = _build_ha_likelihood_fn(spec, param_names, data_mat, observables,
-                                     measurement_error, ha_method, ha_kwargs)
+                                     measurement_error, ha_method, ha_kwargs;
+                                     failures=lik_failures, evals=lik_evals)
 
     # ── 6. Random-Walk Metropolis-Hastings ───────────────────────────────
     # Initialize
@@ -456,7 +474,8 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
             post_draws, post_log_posterior, param_names, prior,
             log_ml, :rwmh, acceptance_rate,
             T[], T[],  # no ESS history or phi schedule for MH
-            linear_sol.spec, linear_sol, ss_result
+            linear_sol.spec, linear_sol, ss_result,
+            lik_failures[], lik_evals[]
         )
     else
         # KrusellSmithSolution or other — build a minimal DSGESolution

--- a/src/dsge/heterogeneous/estimation.jl
+++ b/src/dsge/heterogeneous/estimation.jl
@@ -494,7 +494,7 @@ function estimate_dsge_bayes(spec::HADSGESpec{T}, data::AbstractMatrix,
             log_ml, :rwmh, acceptance_rate,
             T[], T[],  # no ESS history or phi schedule for MH
             linear_sol.spec, linear_sol, ss_result,
-            lik_failures[], lik_evals[]
+            lik_failures[], lik_evals[], :posterior_mean  # solved_at refined in [T050]/#149
         )
     else
         # KrusellSmithSolution or other — build a minimal DSGESolution

--- a/src/dsge/kalman_dsge.jl
+++ b/src/dsge/kalman_dsge.jl
@@ -175,8 +175,13 @@ prediction error decomposition (Harvey 1989, Hamilton 1994 Ch. 13).
 Scalar log-likelihood (sum over t of log p(y_t | y_{1:t-1})).
 
 # Implementation notes
-- **Initialization**: stationary distribution via `solve_lyapunov`; falls back to
-  diffuse initialization (P0 = 10 * I) if Lyapunov equation fails (e.g., unit root).
+- **Initialization**: stationary distribution via `solve_lyapunov` when all transition
+  eigenvalues have modulus `< 1`. For unit roots (any `|eig(G1)| ≥ 1 - 1e-6`), the
+  initial covariance uses a finite Lyapunov solution on the stationary subspace plus
+  a large diffuse variance (κ = 1e6) on the nonstationary subspace, via
+  `_diffuse_initial_covariance` (Durbin & Koopman 2012, ch. 5), emitting a one-time
+  warning — never a silent `P0 = 10*I`. Non-stability exceptions (`MethodError`,
+  `DimensionMismatch`, etc.) propagate rather than being swallowed.
 - **Pre-allocation**: all workspace matrices allocated once before the loop.
 - **BLAS**: uses `mul!` for matrix-vector and matrix-matrix products (Level 2/3 BLAS).
 - **Missing data**: NaN entries in `data` are handled by reducing the observation
@@ -191,12 +196,13 @@ function _kalman_loglikelihood(ss::DSGEStateSpace{T}, data::Matrix{T}) where {T<
     # --- Initialization ---
     x = zeros(T, n_states)  # initial state mean (deviation from SS = 0)
 
-    # Stationary covariance via Lyapunov equation; diffuse fallback
+    # Stationary covariance via Lyapunov equation; eigenvalue-partitioned diffuse
+    # initialization for unit roots (never a silent P0=10I; non-stability errors propagate).
     RQR = ss.impact * ss.Q * ss.impact'
-    P = try
+    P = if maximum(abs, eigvals(ss.G1)) >= one(T) - T(1e-6)
+        _diffuse_initial_covariance(ss.G1, RQR)
+    else
         solve_lyapunov(ss.G1, ss.impact)
-    catch
-        T(10) * Matrix{T}(I, n_states, n_states)
     end
 
     # --- Pre-allocate workspace (zero inner-loop allocation for full obs) ---

--- a/src/dsge/kalman_dsge.jl
+++ b/src/dsge/kalman_dsge.jl
@@ -36,7 +36,8 @@ The observation equation is: `y_t = Z * x_t + d + v_t`, where `v_t ~ N(0, H)`.
 - `spec` — DSGE model specification
 - `observables` — symbols identifying which endogenous variables are observed
 - `measurement_error` — vector of measurement error standard deviations, or `nothing`
-  for default (1e-4 * I)
+  for zero measurement error (the model-implied covariance is used; requires
+  `n_obs ≤ n_shocks`, else a `StochasticSingularityError` is thrown)
 
 # Returns
 - `Z::Matrix{T}` — n_obs x n_states selection matrix (ones at observable positions)
@@ -71,9 +72,18 @@ function _build_observation_equation(spec::DSGESpec{T}, observables::Vector{Symb
         d = T[spec.steady_state[j] for j in obs_indices]
     end
 
-    # H: measurement error covariance
+    # H: measurement error covariance. Default is ZERO (use the model covariance); a
+    # nonzero default would mask stochastic singularity when n_obs > n_shocks.
     if measurement_error === nothing
-        H = T(1e-4) * Matrix{T}(I, n_obs, n_obs)
+        H = zeros(T, n_obs, n_obs)
+        n_shocks = spec.n_exog
+        if n_obs > n_shocks
+            throw(StochasticSingularityError(
+                "$n_obs observables exceed $n_shocks structural shocks; the model-implied " *
+                "observation covariance is singular and the likelihood is ill-defined. " *
+                "Add measurement error (measurement_error=:auto or a vector of SDs) or " *
+                "reduce the number of observables."))
+        end
     else
         me = Vector{T}(measurement_error)
         length(me) == n_obs || throw(ArgumentError(

--- a/src/dsge/particle_filter.jl
+++ b/src/dsge/particle_filter.jl
@@ -209,9 +209,10 @@ end
     _pf_initialize_stationary!(ws, ss)
 
 Initialize particles from the stationary distribution of the linear state space.
-Computes P0 = solve_lyapunov(G1, impact), takes Cholesky factor L, and draws
-particles[:, i] = L * randn(n_states). Falls back to diffuse initialization
-(10 * I) if Lyapunov fails.
+Computes P0 = solve_lyapunov(G1, impact) when all `|eig(G1)| < 1`, takes Cholesky
+factor L, and draws particles[:, i] = L * randn(n_states). For unit roots
+(`|eig(G1)| ≥ 1 - 1e-6`) uses `_diffuse_initial_covariance` (κ = 1e6 on the
+nonstationary subspace), never a silent 10*I; non-stability errors propagate.
 """
 function _pf_initialize_stationary!(ws::PFWorkspace{T},
                                      ss::DSGEStateSpace{T};
@@ -219,10 +220,11 @@ function _pf_initialize_stationary!(ws::PFWorkspace{T},
     n_states = size(ws.particles, 1)
     N = size(ws.particles, 2)
 
-    P0 = try
+    RQR = ss.impact * ss.Q * ss.impact'
+    P0 = if maximum(abs, eigvals(ss.G1)) >= one(T) - T(1e-6)
+        _diffuse_initial_covariance(ss.G1, RQR)
+    else
         solve_lyapunov(ss.G1, ss.impact)
-    catch
-        T(10) * Matrix{T}(I, n_states, n_states)
     end
 
     # Ensure symmetry and positive definiteness
@@ -500,11 +502,14 @@ function _pf_initialize_nonlinear!(ws::PFWorkspace{T},
     eta_x = nx > 0 ? nlss.hx[:, nx+1:nv] : zeros(T, 0, n_eps)
     gx_state = ny > 0 ? nlss.gx[:, 1:nx] : zeros(T, 0, nx)
 
-    # Compute P0 from first-order Lyapunov equation
-    P0 = try
+    # Compute P0 from first-order Lyapunov equation (diffuse for unit roots; nx==0 → 0×0).
+    RQR_x = eta_x * eta_x'
+    P0 = if nx == 0
+        zeros(T, 0, 0)
+    elseif maximum(abs, eigvals(hx_state)) >= one(T) - T(1e-6)
+        _diffuse_initial_covariance(hx_state, RQR_x)
+    else
         solve_lyapunov(hx_state, eta_x)
-    catch
-        T(10) * Matrix{T}(I, nx, nx)
     end
     P0 = (P0 + P0') / 2
     C = cholesky(Hermitian(P0); check=false)

--- a/src/dsge/particle_filter.jl
+++ b/src/dsge/particle_filter.jl
@@ -148,6 +148,24 @@ function _normalize_log_weights!(weights::Vector{T}, log_weights::Vector{T}) whe
 end
 
 """
+    _pf_increment!(ws::PFWorkspace) -> T
+
+Unbiased incremental log-likelihood factor under adaptive resampling. `ws.cumweights` holds
+the fresh per-particle observation log-densities `log g_t` (written by `_pf_log_weights!`);
+fold them into the running unnormalized cumulative log-weights `ws.log_weights` and return the
+ratio-form increment `logsumexp(L_t) - logsumexp(L_{t-1})`. The plain `logsumexp(log g_t)-log N`
+increment is unbiased only when the incoming weights are uniform (a resample happened last
+step); when adaptive resampling skips a step the carried non-uniform weights must be kept, not
+overwritten (audit R-... / #128). After a resample the caller resets `ws.log_weights` to
+`-log N`, so `lse_prev = 0` here. The caller normalizes `ws.weights` for the ESS test.
+"""
+function _pf_increment!(ws::PFWorkspace{T}) where {T<:AbstractFloat}
+    lse_prev = _logsumexp(ws.log_weights)
+    ws.log_weights .+= ws.cumweights
+    return _logsumexp(ws.log_weights) - lse_prev
+end
+
+"""
     _systematic_resample!(ancestors, weights, cumweights, N, rng)
 
 O(N) systematic resampling into pre-allocated `ancestors` vector.
@@ -281,11 +299,13 @@ function _bootstrap_particle_filter!(ws::PFWorkspace{T}, ss::DSGEStateSpace{T},
 
         # Compute log weights
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        # Fresh observation log-densities into the cumweights scratch (do NOT overwrite the
+        # carried non-uniform weights — #128); cumweights is free until resampling.
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,
                           ws.particles, y_t, ss.Z, ss.d, ss.H_inv, ss.log_det_H)
 
         # Accumulate log-likelihood: log(1/N * sum_k exp(log_w_k))
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -480,11 +500,12 @@ function _conditional_smc!(ws::PFWorkspace{T}, ss::DSGEStateSpace{T},
 
         # Compute log weights
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        # Fresh observation log-densities into the cumweights scratch (#128).
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,
                           ws.particles, y_t, ss.Z, ss.d, ss.H_inv, ss.log_det_H)
 
         # Accumulate log-likelihood
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -949,11 +970,11 @@ function _bootstrap_particle_filter!(ws::PFWorkspace{T}, nlss::NonlinearStateSpa
 
         # Compute log weights using full endogenous particles
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,   # scratch, not overwrite (#128)
                           ws.particles, y_t, nlss.Z, nlss.d, nlss.H_inv, nlss.log_det_H)
 
         # Accumulate log-likelihood
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -1052,11 +1073,11 @@ function _conditional_smc!(ws::PFWorkspace{T}, nlss::NonlinearStateSpace{T},
 
         # Compute log weights
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,   # scratch, not overwrite (#128)
                           ws.particles, y_t, nlss.Z, nlss.d, nlss.H_inv, nlss.log_det_H)
 
         # Accumulate log-likelihood
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -1290,11 +1311,11 @@ function _bootstrap_particle_filter!(ws::PFWorkspace{T}, pss::ProjectionStateSpa
 
         # Compute observation log-weights
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,   # scratch, not overwrite (#128)
                           ws.particles, y_t, pss.Z, pss.d, pss.H_inv, pss.log_det_H)
 
         # Accumulate log-likelihood
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -1310,6 +1331,10 @@ function _bootstrap_particle_filter!(ws::PFWorkspace{T}, pss::ProjectionStateSpa
             _systematic_resample!(ws.ancestors, ws.weights, ws.cumweights, N, rng)
             _resample_particles!(ws.particles_new, ws.particles, ws.ancestors)
             ws.particles, ws.particles_new = ws.particles_new, ws.particles
+            # Resampled particles are uniformly weighted — reset so the next ratio-form
+            # increment's lse_prev = 0 (the projection filters previously omitted this because
+            # the old code overwrote log_weights each step; #128 needs it).
+            fill!(ws.log_weights, -log(T(N)))
         end
     end
 
@@ -1367,11 +1392,11 @@ function _conditional_smc!(ws::PFWorkspace{T}, pss::ProjectionStateSpace{T},
 
         # Compute observation log-weights
         y_t = @view data[:, t]
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
+        _pf_log_weights!(ws.cumweights, ws.innovations, ws.tmp_obs,   # scratch, not overwrite (#128)
                           ws.particles, y_t, pss.Z, pss.d, pss.H_inv, pss.log_det_H)
 
         # Accumulate log-likelihood
-        log_lik += _logsumexp(ws.log_weights) - log_N
+        log_lik += _pf_increment!(ws)   # ratio-form increment, correct under adaptive resampling (#128)
 
         # Normalize weights
         _normalize_log_weights!(ws.weights, ws.log_weights)
@@ -1388,6 +1413,7 @@ function _conditional_smc!(ws::PFWorkspace{T}, pss::ProjectionStateSpace{T},
             ws.ancestors[N] = N  # Reference particle always survives
             _resample_particles!(ws.particles_new, ws.particles, ws.ancestors)
             ws.particles, ws.particles_new = ws.particles_new, ws.particles
+            fill!(ws.log_weights, -log(T(N)))   # uniform after resampling for the ratio-form increment (#128)
         end
 
         # Store trajectory for backward sampling

--- a/src/dsge/particle_filter.jl
+++ b/src/dsge/particle_filter.jl
@@ -8,14 +8,12 @@
 Particle filter compute kernels for Bayesian DSGE estimation.
 
 All functions operate on pre-allocated `PFWorkspace` buffers for zero inner-loop
-allocation. Provides bootstrap particle filter, auxiliary particle filter (Pitt &
-Shephard 1999), and conditional SMC (Andrieu, Doucet & Holenstein 2010).
+allocation. Provides the bootstrap particle filter and conditional SMC (Andrieu,
+Doucet & Holenstein 2010).
 
 References:
 - Gordon, N. J., Salmond, D. J. & Smith, A. F. M. (1993). Novel approach to
   nonlinear/non-Gaussian Bayesian state estimation. IEE Proceedings F, 140(2), 107-113.
-- Pitt, M. K. & Shephard, N. (1999). Filtering via simulation: Auxiliary particle
-  filters. Journal of the American Statistical Association, 94(446), 590-599.
 - Andrieu, C., Doucet, A. & Holenstein, R. (2010). Particle Markov chain Monte Carlo
   methods. Journal of the Royal Statistical Society: Series B, 72(3), 269-342.
 """
@@ -332,108 +330,6 @@ function _bootstrap_particle_filter!(ws::PFWorkspace{T}, ss::DSGEStateSpace{T},
             @simd for s in 1:size(ws.particles, 1)
                 ws.reference_trajectory[s, t] = ws.particles[s, N]
             end
-        end
-    end
-
-    return log_lik
-end
-
-# =============================================================================
-# Auxiliary Particle Filter (Pitt & Shephard 1999)
-# =============================================================================
-
-"""
-    _auxiliary_particle_filter!(ws, ss, data, T_obs; threshold=0.5, rng=Random.default_rng())
-
-Auxiliary particle filter (Pitt & Shephard 1999) for linear state space.
-
-First-stage weights use the predictive mean mu_k = G1 * s_k to compute
-p(y_t | Z * mu_k + d, H) as a Gaussian density. Particles are resampled
-according to first-stage weights, then propagated, and adjustment weights
-are computed.
-
-Returns log marginal likelihood estimate.
-"""
-function _auxiliary_particle_filter!(ws::PFWorkspace{T}, ss::DSGEStateSpace{T},
-                                      data::Matrix{T}, T_obs::Int;
-                                      threshold::Real=0.5,
-                                      rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
-    N = size(ws.particles, 2)
-    n_obs = size(data, 1)
-    n_states = size(ws.particles, 1)
-    log_N = log(T(N))
-    inv_N = one(T) / N
-    half = T(0.5)
-
-    # Initialize from stationary distribution
-    _pf_initialize_stationary!(ws, ss; rng=rng)
-
-    log_lik = zero(T)
-
-    @inbounds for t in 1:T_obs
-        y_t = @view data[:, t]
-
-        # --- First stage: compute predictive mean for each particle ---
-        # particles_new = G1 * particles (predictive mean, no shocks)
-        mul!(ws.particles_new, ss.G1, ws.particles)
-
-        # Compute first-stage log weights using predictive mean
-        # innovations = y_t - Z * mu - d
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
-                          ws.particles_new, y_t, ss.Z, ss.d, ss.H_inv, ss.log_det_H)
-
-        # Add current particle weights (log scale) if not uniform
-        # log_first_stage = log_w_current + log_predictive
-        # (weights start uniform, so this is just the predictive on first step)
-
-        # Normalize and accumulate first-stage contribution
-        lse_first = _logsumexp(ws.log_weights)
-        log_lik += lse_first - log_N
-
-        _normalize_log_weights!(ws.weights, ws.log_weights)
-
-        # Resample based on first-stage weights
-        _systematic_resample!(ws.ancestors, ws.weights, ws.cumweights, N, rng)
-        _resample_particles!(ws.particles_new, ws.particles, ws.ancestors)
-        # Swap: particles now hold resampled particles
-        ws.particles, ws.particles_new = ws.particles_new, ws.particles
-
-        # --- Second stage: propagate with shocks ---
-        randn!(rng, ws.shocks)
-        _pf_transition_linear!(ws.particles_new, ws.particles, ws.shocks,
-                                ss.G1, ss.impact)
-        ws.particles, ws.particles_new = ws.particles_new, ws.particles
-
-        # Compute actual observation log weights
-        _pf_log_weights!(ws.log_weights, ws.innovations, ws.tmp_obs,
-                          ws.particles, y_t, ss.Z, ss.d, ss.H_inv, ss.log_det_H)
-
-        # Compute predictive mean log weights for adjustment
-        # Recompute predictive mean from ancestors (before shock addition)
-        # The adjustment is: log w_adjust = log p(y|x_t) - log p(y|mu_{a_t})
-        # We already have log p(y|x_t) in log_weights
-        # Need to subtract log p(y|mu_{a_t}) which was the first-stage weight
-        # For simplicity with the resampled particles, recompute mu = G1 * particles_before_shock
-        # Since we already propagated, compute from the resampled (pre-shock) state:
-        # pre-shock state = particles (post resample) which is now overwritten
-        # We use the fact that for linear Gaussian, the adjustment is a constant shift
-
-        # Normalize adjustment weights
-        _normalize_log_weights!(ws.weights, ws.log_weights)
-
-        # ESS-based resampling of adjustment weights
-        ess = zero(T)
-        @simd for k in 1:N
-            ess += ws.weights[k] * ws.weights[k]
-        end
-        ess = one(T) / ess
-
-        if ess < threshold * N
-            _systematic_resample!(ws.ancestors, ws.weights, ws.cumweights, N, rng)
-            _resample_particles!(ws.particles_new, ws.particles, ws.ancestors)
-            ws.particles, ws.particles_new = ws.particles_new, ws.particles
-            fill!(ws.weights, inv_N)
-            fill!(ws.log_weights, -log_N)
         end
     end
 

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -239,6 +239,27 @@ function _adaptive_tempering(log_liks::AbstractVector{T}, log_weights::AbstractV
 end
 
 """
+    _chunk_ranges(N, k) -> Vector{UnitRange{Int}}
+
+Partition `1:N` into `k` contiguous, near-equal chunks (trailing ranges are empty
+when `N < k`). Used to give each parallel task a **stable, dedicated** workspace by
+chunk index rather than `threadid()` — the latter is unsafe under Julia's dynamic
+scheduler, where a migrated task's `threadid()` can collide with another live task's
+and alias the same particle-filter workspace (E-06 / #134; generalized in #146).
+"""
+function _chunk_ranges(N::Int, k::Int)
+    ranges = Vector{UnitRange{Int}}(undef, k)
+    base, rem = divrem(N, k)
+    start = 1
+    @inbounds for c in 1:k
+        len = base + (c <= rem ? 1 : 0)
+        ranges[c] = start:(start + len - 1)
+        start += len
+    end
+    return ranges
+end
+
+"""
     _terminal_resample!(state, N, rng) -> Bool
 
 Systematic resample of the SMC particles at termination (E-09 / #132).
@@ -1252,114 +1273,128 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         # (MersenneTwister is NOT thread-safe)
         particle_seeds_mut = [hash((j, phi_new, rand(rng, UInt64))) for j in 1:N]
 
-        Threads.@threads for j in 1:N
-            thread_rng = Random.MersenneTwister(particle_seeds_mut[j])
-            ws = pool[mod1(Threads.threadid(), n_pool)]
+        # PMMH mutation (E-06 / #134). Each θ-particle's move is a particle-marginal
+        # Metropolis-Hastings step: a FRESH unconditional bootstrap PF gives an unbiased
+        # likelihood estimate for θ*, compared against the stored incumbent PF estimate for
+        # θ_j (kept noisy on accept — Andrieu-Doucet-Holenstein 2010). The old conditional-SMC
+        # (CSMC) path is dropped from acceptance: CSMC estimates are conditional on a reference
+        # trajectory and biased for parameter inference, and the pooled reference trajectory was
+        # additionally contaminated across θ-particles via threadid()-indexed workspaces.
+        #
+        # Parallelism is chunk-based: partition the θ-particles into n_pool contiguous chunks,
+        # one PF workspace per chunk, so no workspace is shared across concurrently-running tasks.
+        chunk_ranges = _chunk_ranges(N, n_pool)
 
-            theta_j = state.theta_particles[:, j]
-            ll_j = state.log_likelihoods[j]
-            lp_j = state.log_priors[j]
+        Threads.@threads for c in eachindex(chunk_ranges)
+            ws = pool[c]
+            ws_screen = delayed_acceptance ? screen_pool[c] : ws
+            for j in chunk_ranges[c]
+                thread_rng = Random.MersenneTwister(particle_seeds_mut[j])
 
-            for _ in 1:n_mh_steps
-                # Propose: theta_star = theta_j + L * z
-                z = randn(thread_rng, T, n_params)
-                theta_star = theta_j + L * z
+                theta_j = state.theta_particles[:, j]
+                ll_j = state.log_likelihoods[j]   # incumbent unbiased PF estimate (PMMH)
+                lp_j = state.log_priors[j]
 
-                # Evaluate prior
-                lp_star = _log_prior(theta_star, prior)
-                if lp_star == T(-Inf)
+                for _ in 1:n_mh_steps
+                    # Propose: theta_star = theta_j + L * z (symmetric RW ⇒ q-terms cancel)
+                    z = randn(thread_rng, T, n_params)
+                    theta_star = theta_j + L * z
+
+                    # Evaluate prior
+                    lp_star = _log_prior(theta_star, prior)
+                    if lp_star == T(-Inf)
+                        Threads.atomic_add!(total_proposed, 1)
+                        continue
+                    end
+
+                    # Build solver_kwargs with warm-starting from cached solution
+                    mh_solver_kwargs = if solver in (:projection, :pfi) && solutions[j] isa ProjectionSolution
+                        merge(solver_kwargs, (initial_coeffs=solutions[j].coefficients,))
+                    else
+                        solver_kwargs
+                    end
+
+                    if delayed_acceptance
+                        # ── Two-stage delayed acceptance (Christen & Fox 2005) on top of PMMH ──
+                        # Stage 1: cheap bootstrap-PF screen.
+                        ll_cheap_star = _solve_and_run_pf(
+                            spec, param_names, theta_star, observables, measurement_error,
+                            solver, mh_solver_kwargs, ws_screen, data, T_obs, thread_rng)
+
+                        if ll_cheap_star == T(-Inf)
+                            Threads.atomic_add!(total_proposed, 1)
+                            continue
+                        end
+
+                        # Stage 1 acceptance ratio (using cheap likelihoods)
+                        log_alpha_1 = (phi_new * ll_cheap_star + lp_star) -
+                                      (phi_new * ll_cheap[j] + lp_j)
+
+                        if log(rand(thread_rng, T)) >= log_alpha_1
+                            # Stage 1 rejects — skip the expensive PF
+                            Threads.atomic_add!(total_proposed, 1)
+                            continue
+                        end
+
+                        # Stage 2: fresh UNCONDITIONAL bootstrap PF (unbiased ⇒ PMMH-exact).
+                        ll_star, sol_star = _solve_and_run_pf(
+                            spec, param_names, theta_star, observables, measurement_error,
+                            solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
+                            use_csmc=false, return_solution=true)
+
+                        if ll_star == T(-Inf)
+                            Threads.atomic_add!(total_proposed, 1)
+                            continue
+                        end
+
+                        # Stage 2 acceptance ratio (delayed-acceptance correction term)
+                        log_alpha_2 = phi_new * (ll_star - ll_cheap_star) -
+                                      phi_new * (ll_j - ll_cheap[j])
+
+                        if log(rand(thread_rng, T)) < log_alpha_2
+                            theta_j = theta_star
+                            ll_j = ll_star
+                            lp_j = lp_star
+                            ll_cheap[j] = ll_cheap_star
+                            if sol_star isa ProjectionSolution
+                                solutions[j] = sol_star
+                            end
+                            Threads.atomic_add!(total_accepted, 1)
+                        end
+                    else
+                        # ── Standard single-stage PMMH: fresh unconditional bootstrap PF ──
+                        ll_star, sol_star = _solve_and_run_pf(
+                            spec, param_names, theta_star, observables, measurement_error,
+                            solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
+                            use_csmc=false, return_solution=true)
+
+                        if ll_star == T(-Inf)
+                            Threads.atomic_add!(total_proposed, 1)
+                            continue
+                        end
+
+                        # PMMH acceptance: unbiased PF estimate for θ* vs stored incumbent for θ_j.
+                        log_alpha = (phi_new * ll_star + lp_star) - (phi_new * ll_j + lp_j)
+
+                        if log(rand(thread_rng, T)) < log_alpha
+                            theta_j = theta_star
+                            ll_j = ll_star   # keep the noisy accepted estimate (PMMH)
+                            lp_j = lp_star
+                            if sol_star isa ProjectionSolution
+                                solutions[j] = sol_star
+                            end
+                            Threads.atomic_add!(total_accepted, 1)
+                        end
+                    end
+
                     Threads.atomic_add!(total_proposed, 1)
-                    continue
                 end
 
-                # Build solver_kwargs with warm-starting from cached solution
-                mh_solver_kwargs = if solver in (:projection, :pfi) && solutions[j] isa ProjectionSolution
-                    merge(solver_kwargs, (initial_coeffs=solutions[j].coefficients,))
-                else
-                    solver_kwargs
-                end
-
-                if delayed_acceptance
-                    # ── Two-stage delayed acceptance (Christen & Fox 2005) ──
-                    # Stage 1: cheap bootstrap PF screening
-                    ws_screen = screen_pool[mod1(Threads.threadid(), length(screen_pool))]
-                    ll_cheap_star = _solve_and_run_pf(
-                        spec, param_names, theta_star, observables, measurement_error,
-                        solver, mh_solver_kwargs, ws_screen, data, T_obs, thread_rng)
-
-                    if ll_cheap_star == T(-Inf)
-                        Threads.atomic_add!(total_proposed, 1)
-                        continue
-                    end
-
-                    # Stage 1 acceptance ratio (using cheap likelihoods)
-                    log_alpha_1 = (phi_new * ll_cheap_star + lp_star) -
-                                  (phi_new * ll_cheap[j] + lp_j)
-
-                    if log(rand(thread_rng, T)) >= log_alpha_1
-                        # Stage 1 rejects — skip expensive CSMC
-                        Threads.atomic_add!(total_proposed, 1)
-                        continue
-                    end
-
-                    # Stage 2: full CSMC (only reached if Stage 1 accepts)
-                    ll_star, sol_star = _solve_and_run_pf(
-                        spec, param_names, theta_star, observables, measurement_error,
-                        solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
-                        use_csmc=true, return_solution=true)
-
-                    if ll_star == T(-Inf)
-                        Threads.atomic_add!(total_proposed, 1)
-                        continue
-                    end
-
-                    # Stage 2 acceptance ratio (correction term)
-                    log_alpha_2 = phi_new * (ll_star - ll_cheap_star) -
-                                  phi_new * (ll_j - ll_cheap[j])
-
-                    if log(rand(thread_rng, T)) < log_alpha_2
-                        theta_j = theta_star
-                        ll_j = ll_star
-                        lp_j = lp_star
-                        ll_cheap[j] = ll_cheap_star
-                        if sol_star isa ProjectionSolution
-                            solutions[j] = sol_star
-                        end
-                        Threads.atomic_add!(total_accepted, 1)
-                    end
-                else
-                    # ── Standard single-stage MH ──
-                    ll_star, sol_star = _solve_and_run_pf(
-                        spec, param_names, theta_star, observables, measurement_error,
-                        solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
-                        use_csmc=true, return_solution=true)
-
-                    if ll_star == T(-Inf)
-                        Threads.atomic_add!(total_proposed, 1)
-                        continue
-                    end
-
-                    # MH acceptance ratio (tempered)
-                    log_alpha = (phi_new * ll_star + lp_star) - (phi_new * ll_j + lp_j)
-
-                    if log(rand(thread_rng, T)) < log_alpha
-                        theta_j = theta_star
-                        ll_j = ll_star
-                        lp_j = lp_star
-                        if sol_star isa ProjectionSolution
-                            solutions[j] = sol_star
-                        end
-                        Threads.atomic_add!(total_accepted, 1)
-                    end
-                end
-
-                Threads.atomic_add!(total_proposed, 1)
+                # Write back
+                state.theta_particles[:, j] = theta_j
+                state.log_likelihoods[j] = ll_j
+                state.log_priors[j] = lp_j
             end
-
-            # Write back
-            state.theta_particles[:, j] = theta_j
-            state.log_likelihoods[j] = ll_j
-            state.log_priors[j] = lp_j
         end
 
         # Record acceptance rate

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -1134,6 +1134,53 @@ function _build_pf_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
 end
 
 """
+    _smc2_init_likelihoods!(log_likelihoods, solutions, theta_particles, spec,
+                            param_names, observables, measurement_error, solver,
+                            solver_kwargs, pf_ll_fn, pool, data, T_obs, seeds;
+                            failures, evals) -> Nothing
+
+Evaluate each SMC² θ-particle's initial PF log-likelihood in parallel (E-23 / #147).
+Partitions the particles into `length(pool)` contiguous chunks (`_chunk_ranges`), gives
+each chunk its **own** PF workspace (chunk-indexed, never `threadid()`-indexed — safe
+under Julia's dynamic scheduler, #146), and seeds each particle's PF from the
+caller-supplied pre-generated `seeds[j]`. The result is therefore **identical to a
+serial run regardless of thread count**. `pf_ll_fn` and the projection-branch
+`_solve_and_run_pf` share the sampler's failure/eval atomics via `failures`/`evals`.
+"""
+function _smc2_init_likelihoods!(log_likelihoods::Vector{T}, solutions::Vector{Any},
+        theta_particles::AbstractMatrix{T}, spec::DSGESpec{T},
+        param_names::Vector{Symbol}, observables::Vector{Symbol}, measurement_error,
+        solver::Symbol, solver_kwargs::NamedTuple, pf_ll_fn,
+        pool::Vector{PFWorkspace{T}}, data::Matrix{T}, T_obs::Int,
+        seeds::AbstractVector{<:Integer};
+        failures::Threads.Atomic{Int}=Threads.Atomic{Int}(0),
+        evals::Threads.Atomic{Int}=Threads.Atomic{Int}(0)) where {T<:AbstractFloat}
+    N = size(theta_particles, 2)
+    ranges = _chunk_ranges(N, length(pool))
+    Threads.@threads for c in eachindex(ranges)
+        ws = pool[c]
+        for j in ranges[c]
+            thread_rng = Random.MersenneTwister(seeds[j])
+            if solver in (:projection, :pfi)
+                ll_j, sol_j = _solve_and_run_pf(spec, param_names,
+                    Vector{T}(theta_particles[:, j]), observables,
+                    measurement_error, solver, solver_kwargs,
+                    ws, data, T_obs, thread_rng;
+                    store_trajectory=true, return_solution=true,
+                    failures=failures, evals=evals)
+                log_likelihoods[j] = ll_j
+                if sol_j isa ProjectionSolution
+                    solutions[j] = sol_j
+                end
+            else
+                log_likelihoods[j] = pf_ll_fn(Vector{T}(theta_particles[:, j]), ws, thread_rng)
+            end
+        end
+    end
+    return nothing
+end
+
+"""
     _smc2_sample(spec, data, param_names, prior, θ0; kwargs...) → SMCState
 
 SMC² algorithm (Chopin, Jacob & Papaspiliopoulos 2013) that nests a particle
@@ -1314,37 +1361,30 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     # Initialize weights uniformly
     log_weights = fill(-log(T(N)), N)
 
-    # Evaluate log-likelihoods via PF (and cache solutions for warm-starting)
+    # Evaluate log-likelihoods via PF (and cache solutions for warm-starting), threaded
+    # with per-chunk workspaces (#147). Pre-generate the per-particle seeds BEFORE threading,
+    # in j-order, so the rng-consumption order — and hence the result and downstream rng state
+    # — are bit-identical to the old serial loop and independent of thread count.
     log_likelihoods = fill(T(-Inf), N)
-    for j in 1:N
-        ws_idx = mod1(j, n_pool)
-        thread_rng = Random.MersenneTwister(hash((j, rand(rng, UInt64))))
-        if solver in (:projection, :pfi)
-            ll_j, sol_j = _solve_and_run_pf(spec, param_names,
-                                              theta_particles[:, j], observables,
-                                              measurement_error, solver, solver_kwargs,
-                                              pool[ws_idx], data, T_obs, thread_rng;
-                                              store_trajectory=true, return_solution=true,
-                                              failures=lik_failures, evals=lik_evals)
-            log_likelihoods[j] = ll_j
-            if sol_j isa ProjectionSolution
-                solutions[j] = sol_j
-            end
-        else
-            log_likelihoods[j] = pf_ll_fn(theta_particles[:, j], pool[ws_idx], thread_rng)
-        end
-    end
+    init_seeds = UInt64[hash((j, rand(rng, UInt64))) for j in 1:N]
+    _smc2_init_likelihoods!(log_likelihoods, solutions, theta_particles, spec,
+        param_names, observables, measurement_error, solver, solver_kwargs, pf_ll_fn,
+        pool, data, T_obs, init_seeds; failures=lik_failures, evals=lik_evals)
 
-    # Compute cheap screening likelihoods for delayed acceptance
+    # Compute cheap screening likelihoods for delayed acceptance (same chunked pattern).
     if delayed_acceptance
-        for j in 1:N
-            ws_idx = mod1(j, n_pool)
-            screen_rng = Random.MersenneTwister(hash((j, UInt64(0xDA), rand(rng, UInt64))))
-            ll_cheap[j] = _solve_and_run_pf(spec, param_names,
-                                              theta_particles[:, j], observables,
-                                              measurement_error, solver, solver_kwargs,
-                                              screen_pool[ws_idx], data, T_obs, screen_rng;
-                                              store_trajectory=false)
+        screen_ranges = _chunk_ranges(N, n_pool)
+        screen_seeds = UInt64[hash((j, UInt64(0xDA), rand(rng, UInt64))) for j in 1:N]
+        Threads.@threads for c in eachindex(screen_ranges)
+            ws = screen_pool[c]
+            for j in screen_ranges[c]
+                screen_rng = Random.MersenneTwister(screen_seeds[j])
+                ll_cheap[j] = _solve_and_run_pf(spec, param_names,
+                                                  Vector{T}(theta_particles[:, j]), observables,
+                                                  measurement_error, solver, solver_kwargs,
+                                                  ws, data, T_obs, screen_rng;
+                                                  store_trajectory=false)
+            end
         end
     end
 

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -828,14 +828,83 @@ end
 # =============================================================================
 
 """
-    _adapt_n_particles(N_x::Int, var_ll::Real, threshold::Real) → Int
+    _adapt_n_particles(N_x::Int, est_var::Real, threshold::Real) → Int
 
-Adapt the number of internal particles for SMC². If the variance of
-log-likelihood estimates across θ-particles exceeds `threshold`, double `N_x`.
-Otherwise return `N_x` unchanged.
+Adapt the number of inner state particles for SMC². If the **PF estimator
+variance** at fixed θ (see [`_pf_estimator_variance`](@ref)) exceeds `threshold`,
+double `N_x`; otherwise return `N_x` unchanged. Chopin et al. (2013) §3.4 target a
+log-likelihood-estimator variance of roughly 1–3.
 """
-function _adapt_n_particles(N_x::Int, var_ll::Real, threshold::Real)
-    return var_ll > threshold ? 2 * N_x : N_x
+function _adapt_n_particles(N_x::Int, est_var::Real, threshold::Real)
+    return est_var > threshold ? 2 * N_x : N_x
+end
+
+"""
+    _pf_estimator_variance(spec, param_names, theta_particles, observables,
+                           measurement_error, solver, solver_kwargs, pool, data,
+                           T_obs, rng; n_probe, n_rep) -> T
+
+Estimate the variance of the particle-filter log-likelihood estimator **at fixed θ**
+(Chopin et al. 2013 §3.4) — the quantity that should trigger `N_x` adaptation.
+
+Probes `n_probe` θ-particles (evenly spaced through the population) with `n_rep`
+fresh, independent bootstrap PFs each, and returns the mean over probes of the
+per-θ variance of `log p̂(y|θ)`. This measures the **estimator noise** at a fixed
+parameter, NOT `var(ll across θ)` — the spread of the likelihood across the
+θ-population, which is large on any diffuse posterior and would trigger spurious
+doubling (E-11 / #135). Returns `0` when fewer than two finite replicates exist.
+"""
+function _pf_estimator_variance(spec::DSGESpec{T}, param_names::Vector{Symbol},
+        theta_particles::AbstractMatrix{T}, observables::Vector{Symbol},
+        measurement_error, solver::Symbol, solver_kwargs::NamedTuple,
+        pool::Vector{PFWorkspace{T}}, data::Matrix{T}, T_obs::Int,
+        rng::AbstractRNG; n_probe::Int=8, n_rep::Int=2) where {T<:AbstractFloat}
+    N = size(theta_particles, 2)
+    n_probe = min(n_probe, N)
+    (n_probe < 1 || n_rep < 2) && return zero(T)
+    idx = unique(round.(Int, range(1, N; length=n_probe)))
+    ws = pool[1]
+    per_theta = T[]
+    for i in idx
+        theta_i = Vector{T}(theta_particles[:, i])
+        reps = T[]
+        for r in 1:n_rep
+            rr = Random.MersenneTwister(hash((:nx_probe, i, r, rand(rng, UInt64))))
+            ll = _solve_and_run_pf(spec, param_names, theta_i, observables,
+                measurement_error, solver, solver_kwargs, ws, data, T_obs, rr)
+            isfinite(ll) && push!(reps, ll)
+        end
+        length(reps) >= 2 && push!(per_theta, var(reps))
+    end
+    return isempty(per_theta) ? zero(T) : mean(per_theta)
+end
+
+"""
+    _exchange_step!(state, spec, param_names, observables, measurement_error,
+                    solver, solver_kwargs, pool, data, T_obs, rng) -> Nothing
+
+Chopin et al. (2013) §3.4 **exchange step**: after `N_x` changes, re-run a fresh
+unconditional bootstrap PF for EVERY θ-particle at the new `N_x` (the `pool`
+workspaces must already be resized) and replace the stored `log_likelihoods`, so
+the outer θ-weights are not a mix of estimates computed at two different `N_x`.
+"""
+function _exchange_step!(state::SMCState{T}, spec::DSGESpec{T},
+        param_names::Vector{Symbol}, observables::Vector{Symbol}, measurement_error,
+        solver::Symbol, solver_kwargs::NamedTuple, pool::Vector{PFWorkspace{T}},
+        data::Matrix{T}, T_obs::Int, rng::AbstractRNG) where {T<:AbstractFloat}
+    N = size(state.theta_particles, 2)
+    ranges = _chunk_ranges(N, length(pool))
+    seeds = [hash((:exchange, j, rand(rng, UInt64))) for j in 1:N]
+    Threads.@threads for c in eachindex(ranges)
+        ws = pool[c]
+        for j in ranges[c]
+            rr = Random.MersenneTwister(seeds[j])
+            state.log_likelihoods[j] = _solve_and_run_pf(spec, param_names,
+                Vector{T}(state.theta_particles[:, j]), observables, measurement_error,
+                solver, solver_kwargs, ws, data, T_obs, rr)
+        end
+    end
+    return nothing
 end
 
 """
@@ -1402,16 +1471,29 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         acc_rate = tp > 0 ? T(total_accepted[]) / T(tp) : zero(T)
         push!(state.acceptance_rates, acc_rate)
 
-        # Adapt N_x if log-likelihood variance is too high
-        finite_lls = filter(isfinite, state.log_likelihoods)
-        if length(finite_lls) > 1
-            var_ll = var(finite_lls)
-            N_x_new = _adapt_n_particles(N_x, var_ll, T(10))
+        # Adapt N_x on the PF ESTIMATOR variance at fixed θ (Chopin et al. 2013 §3.4),
+        # NOT var(ll across θ) which just reflects posterior spread and doubles N_x
+        # spuriously on any diffuse posterior (E-11 / #135).
+        #
+        # A cheap gate keeps the common case free: only when the PMMH acceptance rate
+        # collapses (the signature of a too-noisy likelihood estimate) do we spend the
+        # duplicate-run variance probe. A healthy chain — including on a diffuse posterior
+        # with good acceptance — skips the probe entirely and N_x is left unchanged, so
+        # N_x is never doubled merely because the posterior is diffuse.
+        if acc_rate < T(0.15)
+            est_var = _pf_estimator_variance(spec, param_names, state.theta_particles,
+                observables, measurement_error, solver, solver_kwargs, pool, data, T_obs,
+                rng; n_probe=min(N, 8), n_rep=2)   # target estimator variance ≈ 1–3
+            N_x_new = _adapt_n_particles(N_x, est_var, T(3))
             if N_x_new > N_x
                 N_x = N_x_new
                 for ws in pool
                     _resize_pf_workspace!(ws, N_x)
                 end
+                # Exchange step: recompute ALL θ-likelihoods at the new N_x so the outer
+                # weights are not a mix of estimates from two different N_x (no stale values).
+                _exchange_step!(state, spec, param_names, observables, measurement_error,
+                    solver, solver_kwargs, pool, data, T_obs, rng)
             end
         end
 

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -583,10 +583,15 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                     break
                 end
                 if attempt == 100
-                    # Fallback to midpoint
-                    lo = isfinite(prior.lower[i]) ? prior.lower[i] : T(0)
-                    hi = isfinite(prior.upper[i]) ? prior.upper[i] : T(1)
-                    theta_particles[i, j] = (lo + hi) / 2
+                    # Fail loudly rather than silently substituting the interval midpoint,
+                    # which would distort the prior and hide a pathological prior/model
+                    # region where draws never land in bounds (#150).
+                    throw(ArgumentError(
+                        "SMC prior initialization failed: parameter `$(param_names[i])` " *
+                        "(prior $(prior.distributions[i]), support bounds " *
+                        "[$(prior.lower[i]), $(prior.upper[i])]) produced 100 consecutive " *
+                        "out-of-bounds draws. Check the prior support and model determinacy " *
+                        "in that region."))
                 end
             end
         end
@@ -1349,9 +1354,13 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                     break
                 end
                 if attempt == 100
-                    lo = isfinite(prior.lower[i]) ? prior.lower[i] : T(0)
-                    hi = isfinite(prior.upper[i]) ? prior.upper[i] : T(1)
-                    theta_particles[i, j] = (lo + hi) / 2
+                    # Fail loudly rather than silently substituting the interval midpoint (#150).
+                    throw(ArgumentError(
+                        "SMC prior initialization failed: parameter `$(param_names[i])` " *
+                        "(prior $(prior.distributions[i]), support bounds " *
+                        "[$(prior.lower[i]), $(prior.upper[i])]) produced 100 consecutive " *
+                        "out-of-bounds draws. Check the prior support and model determinacy " *
+                        "in that region."))
                 end
             end
         end

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -77,12 +77,15 @@ Closure `(θ::Vector{T}) → T` returning log-likelihood or `-Inf`.
 function _build_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
                                data::AbstractMatrix, observables::Vector{Symbol},
                                measurement_error, solver::Symbol,
-                               solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+                               solver_kwargs::NamedTuple;
+                               failures::Threads.Atomic{Int}=Threads.Atomic{Int}(0),
+                               evals::Threads.Atomic{Int}=Threads.Atomic{Int}(0)) where {T<:AbstractFloat}
     data = Matrix{T}(data)  # convert Adjoint/SubArray to concrete Matrix
     # Pre-build observation equation from spec (indices don't change across θ)
     # But steady state changes, so we rebuild each time
 
     function ll_fn(theta::Vector{T})
+        Threads.atomic_add!(evals, 1)
         try
             # Update parameter values
             new_pv = copy(spec.param_values)
@@ -99,11 +102,13 @@ function _build_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
             # Solve model
             sol = solve(new_spec; method=solver, solver_kwargs...)
             if !is_determined(sol)
+                Threads.atomic_add!(failures, 1)
                 return T(-Inf)
             end
 
             # Guard: Kalman filter only valid for linear (1st-order) solutions
             if sol isa PerturbationSolution && sol.order >= 2
+                Threads.atomic_add!(failures, 1)
                 return T(-Inf)  # use :smc2 method for nonlinear models
             end
 
@@ -119,9 +124,19 @@ function _build_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
             # Evaluate Kalman log-likelihood
             ll = _kalman_loglikelihood(ss, data)
 
-            return isfinite(ll) ? ll : T(-Inf)
-        catch
-            return T(-Inf)
+            if isfinite(ll)
+                return ll
+            else
+                Threads.atomic_add!(failures, 1)
+                return T(-Inf)
+            end
+        catch e
+            # Only benign per-θ numeric failures become -Inf (counted); bugs propagate.
+            if _benign_solve_error(e)
+                Threads.atomic_add!(failures, 1)
+                return T(-Inf)
+            end
+            rethrow(e)
         end
     end
 
@@ -520,9 +535,12 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     n_params = length(param_names)
     N = n_smc
 
-    # Build likelihood function
+    # Build likelihood function (tracking failed/total likelihood evaluations)
+    lik_failures = Threads.Atomic{Int}(0)
+    lik_evals = Threads.Atomic{Int}(0)
     ll_fn = _build_likelihood_fn(spec, param_names, data, observables,
-                                  measurement_error, solver, solver_kwargs)
+                                  measurement_error, solver, solver_kwargs;
+                                  failures=lik_failures, evals=lik_evals)
 
     # Initialize particles from prior
     theta_particles = zeros(T, n_params, N)
@@ -657,6 +675,8 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     # Terminal resample so the stored draws are equal-weighted (E-09 / #132).
     _terminal_resample!(state, N, rng)
 
+    state.n_lik_failures = lik_failures[]
+    state.n_lik_evals = lik_evals[]
     return state
 end
 
@@ -722,9 +742,12 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     data = Matrix{T}(data)  # convert Adjoint/SubArray to concrete Matrix
     n_params = length(param_names)
 
-    # Build likelihood function
+    # Build likelihood function (tracking failed/total likelihood evaluations)
+    lik_failures = Threads.Atomic{Int}(0)
+    lik_evals = Threads.Atomic{Int}(0)
     ll_fn = _build_likelihood_fn(spec, param_names, data, observables,
-                                  measurement_error, solver, solver_kwargs)
+                                  measurement_error, solver, solver_kwargs;
+                                  failures=lik_failures, evals=lik_evals)
 
     # Initialize
     theta_current = copy(theta0)
@@ -856,7 +879,8 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                    proposal_L_at_burnin = proposal_L_at_burnin,
                    scale_at_burnin = scale_at_burnin,
                    window_acc_history = window_acc_history,
-                   cum_acc_history = cum_acc_history)
+                   cum_acc_history = cum_acc_history,
+                   n_failed = lik_failures[], n_evals = lik_evals[])
 
     return draws, log_posterior, acceptance_rate, diagnostics
 end
@@ -970,8 +994,11 @@ function _solve_and_run_pf(spec::DSGESpec{T}, param_names::Vector{Symbol},
                             rng::AbstractRNG;
                             use_csmc::Bool=false,
                             store_trajectory::Bool=false,
-                            return_solution::Bool=false) where {T<:AbstractFloat}
+                            return_solution::Bool=false,
+                            failures::Threads.Atomic{Int}=Threads.Atomic{Int}(0),
+                            evals::Threads.Atomic{Int}=Threads.Atomic{Int}(0)) where {T<:AbstractFloat}
     fail = return_solution ? (T(-Inf), nothing) : T(-Inf)
+    Threads.atomic_add!(evals, 1)
     try
         # Update parameter values
         new_pv = copy(spec.param_values)
@@ -986,6 +1013,7 @@ function _solve_and_run_pf(spec::DSGESpec{T}, param_names::Vector{Symbol},
         new_spec = compute_steady_state(new_spec)
         sol = solve(new_spec; method=solver, solver_kwargs...)
         if !is_determined(sol)
+            Threads.atomic_add!(failures, 1)
             return fail
         end
 
@@ -1013,10 +1041,17 @@ function _solve_and_run_pf(spec::DSGESpec{T}, param_names::Vector{Symbol},
                                               store_trajectory=store_trajectory, rng=rng)
         end
 
-        ll = isfinite(ll) ? ll : T(-Inf)
+        if !isfinite(ll)
+            Threads.atomic_add!(failures, 1)
+            ll = T(-Inf)
+        end
         return return_solution ? (ll, sol) : ll
-    catch
-        return fail
+    catch e
+        if _benign_solve_error(e)
+            Threads.atomic_add!(failures, 1)
+            return fail
+        end
+        rethrow(e)
     end
 end
 
@@ -1049,7 +1084,9 @@ function _build_pf_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
                                    data::AbstractMatrix, observables::Vector{Symbol},
                                    measurement_error, solver::Symbol,
                                    solver_kwargs::NamedTuple,
-                                   n_particles::Int) where {T<:AbstractFloat}
+                                   n_particles::Int;
+                                   failures::Threads.Atomic{Int}=Threads.Atomic{Int}(0),
+                                   evals::Threads.Atomic{Int}=Threads.Atomic{Int}(0)) where {T<:AbstractFloat}
     data = Matrix{T}(data)
     T_obs = size(data, 2)
 
@@ -1057,7 +1094,8 @@ function _build_pf_likelihood_fn(spec::DSGESpec{T}, param_names::Vector{Symbol},
         return _solve_and_run_pf(spec, param_names, theta, observables,
                                   measurement_error, solver, solver_kwargs,
                                   ws, data, T_obs, rng;
-                                  store_trajectory=true)
+                                  store_trajectory=true,
+                                  failures=failures, evals=evals)
     end
 
     return pf_ll_fn
@@ -1185,9 +1223,12 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         end
     end
 
-    # Build PF likelihood function
+    # Build PF likelihood function (tracking failed/total authoritative likelihood evals)
+    lik_failures = Threads.Atomic{Int}(0)
+    lik_evals = Threads.Atomic{Int}(0)
     pf_ll_fn = _build_pf_likelihood_fn(spec, param_names, data, observables,
-                                        measurement_error, solver, solver_kwargs, N_x)
+                                        measurement_error, solver, solver_kwargs, N_x;
+                                        failures=lik_failures, evals=lik_evals)
 
     # Create workspace pool (one per thread for parallelism)
     n_pool = max(Threads.nthreads(), 1)
@@ -1250,7 +1291,8 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                                               theta_particles[:, j], observables,
                                               measurement_error, solver, solver_kwargs,
                                               pool[ws_idx], data, T_obs, thread_rng;
-                                              store_trajectory=true, return_solution=true)
+                                              store_trajectory=true, return_solution=true,
+                                              failures=lik_failures, evals=lik_evals)
             log_likelihoods[j] = ll_j
             if sol_j isa ProjectionSolution
                 solutions[j] = sol_j
@@ -1447,7 +1489,8 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                         ll_star, sol_star = _solve_and_run_pf(
                             spec, param_names, theta_star, observables, measurement_error,
                             solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
-                            use_csmc=false, return_solution=true)
+                            use_csmc=false, return_solution=true,
+                            failures=lik_failures, evals=lik_evals)
 
                         if ll_star == T(-Inf)
                             Threads.atomic_add!(total_proposed, 1)
@@ -1473,7 +1516,8 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                         ll_star, sol_star = _solve_and_run_pf(
                             spec, param_names, theta_star, observables, measurement_error,
                             solver, mh_solver_kwargs, ws, data, T_obs, thread_rng;
-                            use_csmc=false, return_solution=true)
+                            use_csmc=false, return_solution=true,
+                            failures=lik_failures, evals=lik_evals)
 
                         if ll_star == T(-Inf)
                             Threads.atomic_add!(total_proposed, 1)
@@ -1541,5 +1585,7 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     # Terminal resample so the stored draws are equal-weighted (E-09 / #132).
     _terminal_resample!(state, N, rng)
 
+    state.n_lik_failures = lik_failures[]
+    state.n_lik_evals = lik_evals[]
     return state
 end

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -254,6 +254,32 @@ function _adaptive_tempering(log_liks::AbstractVector{T}, log_weights::AbstractV
 end
 
 """
+    _check_tempering_progress(stage, max_stages, phi, phi_new, min_dphi)
+
+Guard the adaptive-tempering `while` loops against a degenerate likelihood that never
+advances φ to 1 (E-21 / #145). Throws an informative `ErrorException` when either the
+stage count exceeds `max_stages` or the chosen step `phi_new - phi < min_dphi` while
+`phi_new < 1` (a legitimate final jump returns exactly `phi_new == 1`, never flagged).
+Herbst & Schorfheide (2016) use a fixed ~200–500-stage schedule; `max_stages` bounds
+the adaptive analogue.
+"""
+function _check_tempering_progress(stage::Int, max_stages::Int, phi::T,
+                                    phi_new::T, min_dphi::T) where {T<:AbstractFloat}
+    if stage > max_stages
+        error("SMC tempering did not reach φ=1 within max_stages=$(max_stages) stages " *
+              "(stalled at φ=$(phi)). The likelihood likely degenerated (mis-specified " *
+              "model or bad data slice); raise max_stages only if the schedule is " *
+              "legitimately long.")
+    end
+    if phi_new < one(T) && (phi_new - phi) < min_dphi
+        error("SMC tempering stalled: adaptive step Δφ=$(phi_new - phi) < min_dphi=" *
+              "$(min_dphi) at φ=$(phi) (stage $(stage)). The likelihood degenerated — " *
+              "the model/data are likely mis-specified. Aborting rather than spinning.")
+    end
+    return nothing
+end
+
+"""
     _chunk_ranges(N, k) -> Vector{UnitRange{Int}}
 
 Partition `1:N` into `k` contiguous, near-equal chunks (trailing ranges are empty
@@ -530,6 +556,7 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                       measurement_error=nothing,
                       solver::Symbol=:gensys,
                       solver_kwargs::NamedTuple=NamedTuple(),
+                      max_stages::Int=500, min_dphi::Real=1e-10,
                       rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
     data = Matrix{T}(data)  # convert Adjoint/SubArray to concrete Matrix
     n_params = length(param_names)
@@ -596,8 +623,11 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
 
     # Adaptive tempering loop
     phi = zero(T)
+    stage = 0
+    min_step = T(min_dphi)
 
     while phi < one(T)
+        stage += 1
         # Find next tempering parameter
         # Only use particles with finite log-likelihoods for tempering
         valid_lls = copy(state.log_likelihoods)
@@ -608,6 +638,8 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         end
 
         phi_new = _adaptive_tempering(valid_lls, state.log_weights, phi, ess_target, N)
+        # Abort a degenerate-likelihood stall before paying for the expensive mutation (#145).
+        _check_tempering_progress(stage, max_stages, phi, phi_new, min_step)
         delta_phi = phi_new - phi
 
         # Compute incremental log weights
@@ -1167,6 +1199,7 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                        solver_kwargs::NamedTuple=NamedTuple(),
                        delayed_acceptance::Bool=false,
                        n_screen::Int=200,
+                       max_stages::Int=500, min_dphi::Real=1e-10,
                        rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
     data = Matrix{T}(data)
     n_params = length(param_names)
@@ -1336,8 +1369,11 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
 
     # Adaptive tempering loop
     phi = zero(T)
+    stage = 0
+    min_step = T(min_dphi)
 
     while phi < one(T)
+        stage += 1
         # Find next tempering parameter
         valid_lls = copy(state.log_likelihoods)
         for j in 1:N
@@ -1347,6 +1383,8 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         end
 
         phi_new = _adaptive_tempering(valid_lls, state.log_weights, phi, ess_target, N)
+        # Abort a degenerate-likelihood stall before paying for the expensive PF mutation (#145).
+        _check_tempering_progress(stage, max_stages, phi, phi_new, min_step)
         delta_phi = phi_new - phi
 
         # Compute incremental log weights

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -162,16 +162,28 @@ end
 # =============================================================================
 
 """
-    _adaptive_tempering(log_liks, phi_old, ess_target, N)
+    _adaptive_tempering(log_liks, log_weights, phi_old, ess_target, N)
 
-Find `phi_new` via bisection such that the ESS of the incremental importance
-weights `exp((phi_new - phi_old) * log_liks)` equals `ess_target * N`.
+Find `phi_new` via bisection such that the ESS of the **updated cumulative**
+importance weights `W_{n−1,j} · exp((phi_new − phi_old) · ll_j)` equals
+`ess_target · N`.
 
-If ESS at `phi = 1.0` exceeds the target, returns `1.0` (final step).
-Maximum 50 bisection iterations.
+The tempering reweight multiplies into the incoming (possibly non-uniform)
+cumulative weights `log_weights`, so the ESS that governs the step size and the
+resample decision must be evaluated on `log_weights .+ Δφ .* log_liks`, not on
+`Δφ .* log_liks` alone (E-10 / #133). In the log domain, for `lw = log_weights
+.+ Δφ .* log_liks`,
+
+    log ESS(Δφ) = 2·logsumexp(lw) − logsumexp(2·lw).
+
+Under uniform incoming weights this reduces to the old incremental-only form.
+If ESS at `phi = 1.0` exceeds the target, returns `1.0` (final step). Maximum
+50 bisection iterations.
 
 # Arguments
 - `log_liks::Vector{T}` — per-particle log-likelihoods
+- `log_weights::Vector{T}` — current cumulative (unnormalized) log-weights carried
+  into this stage, **before** folding in the tempering reweight
 - `phi_old::T` — current tempering parameter
 - `ess_target::Real` — target ESS as fraction of N (e.g., 0.5)
 - `N::Int` — number of particles
@@ -179,18 +191,18 @@ Maximum 50 bisection iterations.
 # Returns
 `phi_new::T` — next tempering parameter in `(phi_old, 1.0]`.
 """
-function _adaptive_tempering(log_liks::AbstractVector{T}, phi_old::T,
-                              ess_target::Real, N::Int) where {T<:AbstractFloat}
+function _adaptive_tempering(log_liks::AbstractVector{T}, log_weights::AbstractVector{T},
+                              phi_old::T, ess_target::Real, N::Int) where {T<:AbstractFloat}
     target_ess = T(ess_target) * N
 
-    # Helper: compute ESS at a given phi
+    # Helper: ESS of the updated cumulative weights at a given phi.
     function _compute_ess(phi)
         delta_phi = phi - phi_old
-        inc_log_w = delta_phi .* log_liks
-        # Normalize in log space
-        lse = _logsumexp(inc_log_w)
-        w = exp.(inc_log_w .- lse)
-        return one(T) / sum(abs2, w)
+        lw = log_weights .+ delta_phi .* log_liks
+        a = _logsumexp(lw)
+        isfinite(a) || return zero(T)            # all weights collapsed
+        b = _logsumexp(T(2) .* lw)
+        return exp(T(2) * a - b)
     end
 
     # Check if we can jump straight to phi = 1
@@ -224,6 +236,51 @@ function _adaptive_tempering(log_liks::AbstractVector{T}, phi_old::T,
     end
 
     return phi_new
+end
+
+"""
+    _terminal_resample!(state, N, rng) -> Bool
+
+Systematic resample of the SMC particles at termination (E-09 / #132).
+
+When the final tempering stage reaches φ=1 without triggering a resample, the
+stored θ-particles carry **non-uniform** terminal weights. Downstream consumers
+(`posterior_summary` order-statistic quantiles, and the `irf`/`fevd`/`simulate`
+draw selectors that pick particles uniformly) treat `theta_draws` as equally
+weighted, biasing medians, credible intervals and posterior bands. Resampling
+once on the normalized final weights and resetting weights to uniform makes the
+stored draws equal-weighted samples from the φ=1 posterior.
+
+Returns `true` if a resample was performed, `false` when the weights are already
+(numerically) uniform — e.g. the final stage did resample — so there is no
+redundant double resample. Resamples `theta_particles`, `log_likelihoods` and
+`log_priors` (the fields `_smc_state_to_bayesian_dsge` consumes).
+"""
+function _terminal_resample!(state::SMCState{T}, N::Int,
+                              rng::AbstractRNG) where {T<:AbstractFloat}
+    weights = Vector{T}(undef, N)
+    _normalize_log_weights!(weights, state.log_weights)
+    ess = one(T) / sum(abs2, weights)
+    ess >= N * (one(T) - T(1e-8)) && return false   # already uniform → no-op
+
+    ancestors = collect(1:N)
+    cumweights = zeros(T, N)
+    _systematic_resample!(ancestors, weights, cumweights, N, rng)
+
+    theta_new = similar(state.theta_particles)
+    ll_new = similar(state.log_likelihoods)
+    lp_new = similar(state.log_priors)
+    @inbounds for j in 1:N
+        a = ancestors[j]
+        theta_new[:, j] = state.theta_particles[:, a]
+        ll_new[j] = state.log_likelihoods[a]
+        lp_new[j] = state.log_priors[a]
+    end
+    state.theta_particles .= theta_new
+    state.log_likelihoods .= ll_new
+    state.log_priors .= lp_new
+    fill!(state.log_weights, -log(T(N)))
+    return true
 end
 
 # =============================================================================
@@ -511,7 +568,7 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
             end
         end
 
-        phi_new = _adaptive_tempering(valid_lls, phi, ess_target, N)
+        phi_new = _adaptive_tempering(valid_lls, state.log_weights, phi, ess_target, N)
         delta_phi = phi_new - phi
 
         # Compute incremental log weights
@@ -523,8 +580,14 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
             end
         end
 
-        # Update log marginal likelihood: log p(Y) += log(1/N * sum exp(inc_log_w))
-        state.log_marginal_likelihood += _logsumexp(inc_log_w) - log(T(N))
+        # Update log marginal likelihood with the ratio increment (E-08 / #131):
+        #   ΔlogML = logsumexp(log_weights + inc) − logsumexp(log_weights)
+        # using the (unnormalized) cumulative log-weights carried INTO this stage —
+        # i.e. BEFORE folding inc_log_w into state.log_weights below. This reduces to
+        # logsumexp(inc) − log N only when the incoming weights are uniform (right after
+        # a resample); the old uniform form biased logML after any non-resampled stage.
+        state.log_marginal_likelihood +=
+            _logsumexp(state.log_weights .+ inc_log_w) - _logsumexp(state.log_weights)
 
         # Update particle log weights
         state.log_weights .+= inc_log_w
@@ -569,6 +632,9 @@ function _smc_sample(spec::DSGESpec{T}, data::AbstractMatrix,
 
         phi = phi_new
     end
+
+    # Terminal resample so the stored draws are equal-weighted (E-09 / #132).
+    _terminal_resample!(state, N, rng)
 
     return state
 end
@@ -1110,7 +1176,7 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
             end
         end
 
-        phi_new = _adaptive_tempering(valid_lls, phi, ess_target, N)
+        phi_new = _adaptive_tempering(valid_lls, state.log_weights, phi, ess_target, N)
         delta_phi = phi_new - phi
 
         # Compute incremental log weights
@@ -1121,8 +1187,13 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
             end
         end
 
-        # Update log marginal likelihood
-        state.log_marginal_likelihood += _logsumexp(inc_log_w) - log(T(N))
+        # Update log marginal likelihood with the ratio increment (E-08 / #131):
+        #   ΔlogML = logsumexp(log_weights + inc) − logsumexp(log_weights)
+        # using the (unnormalized) cumulative log-weights carried INTO this stage —
+        # BEFORE folding inc_log_w into state.log_weights below. Reduces to the old
+        # logsumexp(inc) − log N only under uniform incoming weights (post-resample).
+        state.log_marginal_likelihood +=
+            _logsumexp(state.log_weights .+ inc_log_w) - _logsumexp(state.log_weights)
 
         # Update particle log weights
         state.log_weights .+= inc_log_w
@@ -1311,6 +1382,9 @@ function _smc2_sample(spec::DSGESpec{T}, data::AbstractMatrix,
 
         phi = phi_new
     end
+
+    # Terminal resample so the stored draws are equal-weighted (E-09 / #132).
+    _terminal_resample!(state, N, rng)
 
     return state
 end

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -665,12 +665,16 @@ end
 # =============================================================================
 
 """
-    _mh_sample(spec, data, param_names, prior, θ0; kwargs...) → (draws, log_posterior, acceptance_rate)
+    _mh_sample(spec, data, param_names, prior, θ0; kwargs...) → (draws, log_posterior, acceptance_rate, diagnostics)
 
 Adaptive Random-Walk Metropolis-Hastings sampler for Bayesian DSGE estimation.
 
-Adapts the proposal covariance every `adapt_interval` steps, targeting 23.4%
-acceptance rate (Roberts & Rosenthal 2001).
+Adapts the proposal covariance and scale every `adapt_interval` steps **during
+burn-in only**, targeting 23.4% acceptance (Roberts & Rosenthal 2001). The proposal
+is frozen at `draw == burnin`, so — with the burn-in discarded by the caller — the
+retained chain runs a fixed proposal and targets the exact posterior (adaptive-MCMC
+validity, Roberts & Rosenthal 2007). The scale is tuned from a **trailing-window**
+acceptance rate (over the last `adapt_interval` draws), not the stale cumulative rate.
 
 # Arguments
 - `spec::DSGESpec{T}` — model specification
@@ -694,10 +698,16 @@ acceptance rate (Roberts & Rosenthal 2001).
 - `draws::Matrix{T}` — `n_draws × n_params` matrix of posterior draws
 - `log_posterior::Vector{T}` — log posterior at each draw
 - `acceptance_rate::T` — overall acceptance rate
+- `diagnostics::NamedTuple` — the frozen end-of-burn-in proposal (`proposal_L_at_burnin`,
+  `scale_at_burnin`), the final proposal (`proposal_L`, `scale_factor`), and the
+  per-interval trailing-window vs cumulative acceptance signals (`window_acc_history`,
+  `cum_acc_history`)
 
 # References
 - Roberts, G. O. & Rosenthal, J. S. (2001). Optimal Scaling for Various
   Metropolis-Hastings Algorithms. *Statistical Science*, 16(4), 351-367.
+- Roberts, G. O. & Rosenthal, J. S. (2007). Coupling and Ergodicity of Adaptive
+  Markov Chain Monte Carlo Algorithms. *Journal of Applied Probability*, 44(2), 458-475.
 """
 function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                      param_names::Vector{Symbol}, prior::DSGEPrior{T},
@@ -753,6 +763,13 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     proposal_L = cholesky(Hermitian(proposal_cov)).L
 
     total_accepted = 0
+    window_accepted = 0
+    # Adaptation is confined to burn-in (Roberts & Rosenthal 2007): the proposal is
+    # frozen at draw == burnin so the retained chain targets the exact posterior.
+    proposal_L_at_burnin = copy(proposal_L)
+    scale_at_burnin = scale_factor
+    window_acc_history = T[]
+    cum_acc_history = T[]
 
     for draw in 1:n_draws
         # Propose
@@ -774,6 +791,7 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                     ll_current = ll_star
                     lp_current = lp_star
                     total_accepted += 1
+                    window_accepted += 1
                 end
             end
         end
@@ -782,45 +800,65 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         draws[draw, :] = theta_current
         log_posterior[draw] = ll_current + lp_current
 
-        # Adapt proposal covariance
-        if draw % adapt_interval == 0 && draw >= 2 * adapt_interval
-            # Use recent draws to update proposal covariance
-            recent_start = max(1, draw - 5 * adapt_interval)
-            recent_draws = draws[recent_start:draw, :]
+        # Adapt proposal covariance and scale — ONLY during burn-in (frozen after).
+        if draw <= burnin && draw % adapt_interval == 0
+            # Trailing-window acceptance signal (not the stale cumulative rate); the
+            # covariance adapts to recent draws, so the scale must too.
+            window_acc = T(window_accepted) / T(adapt_interval)
+            push!(window_acc_history, window_acc)
+            push!(cum_acc_history, T(total_accepted) / T(draw))
+            window_accepted = 0
 
-            if size(recent_draws, 1) > n_params + 1
-                sample_cov = cov(recent_draws)
-                # Ensure positive definiteness
-                sample_cov = (sample_cov + sample_cov') / 2
-                for i in 1:n_params
-                    if sample_cov[i, i] < T(1e-10)
-                        sample_cov[i, i] = T(1e-10)
+            if draw >= 2 * adapt_interval
+                # Use recent draws to update proposal covariance
+                recent_start = max(1, draw - 5 * adapt_interval)
+                recent_draws = draws[recent_start:draw, :]
+
+                if size(recent_draws, 1) > n_params + 1
+                    sample_cov = cov(recent_draws)
+                    # Ensure positive definiteness
+                    sample_cov = (sample_cov + sample_cov') / 2
+                    for i in 1:n_params
+                        if sample_cov[i, i] < T(1e-10)
+                            sample_cov[i, i] = T(1e-10)
+                        end
                     end
+
+                    proposal_cov = c2 * sample_cov
+                    proposal_L_try = try
+                        cholesky(Hermitian(proposal_cov)).L
+                    catch
+                        proposal_cov += T(1e-6) * I
+                        cholesky(Hermitian(proposal_cov)).L
+                    end
+                    proposal_L = proposal_L_try
                 end
 
-                proposal_cov = c2 * sample_cov
-                proposal_L_try = try
-                    cholesky(Hermitian(proposal_cov)).L
-                catch
-                    proposal_cov += T(1e-6) * I
-                    cholesky(Hermitian(proposal_cov)).L
+                # Adapt scale factor to target 23.4% acceptance (trailing window)
+                if window_acc > T(0.30)
+                    scale_factor *= T(1.1)  # accepting too much → increase step size
+                elseif window_acc < T(0.15)
+                    scale_factor *= T(0.9)  # accepting too little → decrease step size
                 end
-                proposal_L = proposal_L_try
             end
+        end
 
-            # Adapt scale factor to target 23.4% acceptance
-            recent_acc = total_accepted / draw
-            if recent_acc > T(0.30)
-                scale_factor *= T(1.1)  # accepting too much → increase step size
-            elseif recent_acc < T(0.15)
-                scale_factor *= T(0.9)  # accepting too little → decrease step size
-            end
+        # Freeze the proposal at the end of burn-in for the retained chain.
+        if draw == burnin
+            proposal_L_at_burnin = copy(proposal_L)
+            scale_at_burnin = scale_factor
         end
     end
 
     acceptance_rate = T(total_accepted) / T(n_draws)
 
-    return draws, log_posterior, acceptance_rate
+    diagnostics = (proposal_L = proposal_L, scale_factor = scale_factor,
+                   proposal_L_at_burnin = proposal_L_at_burnin,
+                   scale_at_burnin = scale_at_burnin,
+                   window_acc_history = window_acc_history,
+                   cum_acc_history = cum_acc_history)
+
+    return draws, log_posterior, acceptance_rate, diagnostics
 end
 
 # =============================================================================

--- a/src/dsge/smoother.jl
+++ b/src/dsge/smoother.jl
@@ -82,12 +82,13 @@ function dsge_smoother(ss::DSGEStateSpace{T}, data::Matrix{T}) where {T<:Abstrac
     # =====================================================================
     x = zeros(T, n_states)  # initial state mean (deviation from SS = 0)
 
-    # Stationary covariance via Lyapunov equation; diffuse fallback
+    # Stationary covariance via Lyapunov equation; eigenvalue-partitioned diffuse
+    # initialization for unit roots (never a silent P0=10I; non-stability errors propagate).
     RQR = ss.impact * ss.Q * ss.impact'
-    P = try
+    P = if maximum(abs, eigvals(ss.G1)) >= one(T) - T(1e-6)
+        _diffuse_initial_covariance(ss.G1, RQR)
+    else
         solve_lyapunov(ss.G1, ss.impact)
-    catch
-        T(10) * Matrix{T}(I, n_states, n_states)
     end
 
     # =====================================================================

--- a/src/dsge/steady_state.jl
+++ b/src/dsge/steady_state.jl
@@ -313,7 +313,9 @@ function _nlopt_steady_state(spec::DSGESpec{T}, constraints::Vector;
     (min_val, min_x, ret) = NLopt.optimize(opt, y0)
 
     if ret ∉ (:SUCCESS, :FTOL_REACHED, :XTOL_REACHED, :STOPVAL_REACHED)
-        throw(ErrorException(
+        # DSGESolveError (not ErrorException): steady-state non-convergence is a legitimate
+        # per-θ failure that Bayesian likelihood closures catch and count, not a code bug.
+        throw(DSGESolveError(
             "NLopt steady state solver did not converge (return code: $ret). " *
             "Try solver=:ipopt with JuMP + Ipopt for large-scale NLP."))
     end

--- a/src/dsge/types.jl
+++ b/src/dsge/types.jl
@@ -657,3 +657,33 @@ end
 
 report(oirf::OccBinIRF) = show(stdout, oirf)
 
+# =============================================================================
+# Exception taxonomy for Bayesian DSGE solve/likelihood failures
+# =============================================================================
+
+"""
+    DSGESolveError <: Exception
+
+Internal DSGE solve/estimation failure that legitimately implies zero posterior
+mass (indeterminacy, no-solution, steady-state non-convergence) — as opposed to a
+code bug. Likelihood closures catch this (and the concrete numeric-failure types in
+[`_benign_solve_error`](@ref)) and return `-Inf`, counting the draw as failed;
+everything else is rethrown.
+"""
+struct DSGESolveError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::DSGESolveError) = print(io, "DSGESolveError: ", e.msg)
+
+"""
+    _benign_solve_error(e) -> Bool
+
+True when `e` is a legitimate per-θ numeric failure that should be caught and
+counted as a failed draw (return `-Inf`), rather than a bug that must propagate.
+"""
+_benign_solve_error(e) = e isa DSGESolveError ||
+                         e isa DomainError ||
+                         e isa LinearAlgebra.SingularException ||
+                         e isa LinearAlgebra.PosDefException ||
+                         e isa LinearAlgebra.LAPACKException
+

--- a/test/coverage/test_dsge_bayes_coverage.jl
+++ b/test/coverage/test_dsge_bayes_coverage.jl
@@ -127,35 +127,6 @@ end
     @test any(!iszero, ws.reference_trajectory[:, T_sim])
 end
 
-@testset "particle_filter: auxiliary PF with various thresholds" begin
-    rng = Random.MersenneTwister(5003)
-    T_sim = 40
-
-    G1 = fill(0.6, 1, 1)
-    impact = fill(0.3, 1, 1)
-    Z = ones(1, 1)
-    d = zeros(1)
-    H_mat = fill(0.01, 1, 1)
-    Q_mat = ones(1, 1)
-
-    ss = M.DSGEStateSpace{Float64}(G1, impact, Z, d, H_mat, Q_mat)
-    data = randn(rng, 1, T_sim)
-
-    N_particles = 20
-    ws = M._allocate_pf_workspace(Float64, 1, 1, 1, N_particles)
-
-    # Very low threshold => rarely resample
-    ll1 = M._auxiliary_particle_filter!(ws, ss, data, T_sim;
-            threshold=0.01, rng=Random.MersenneTwister(5004))
-    @test isfinite(ll1)
-
-    # Very high threshold => always resample
-    ws2 = M._allocate_pf_workspace(Float64, 1, 1, 1, N_particles)
-    ll2 = M._auxiliary_particle_filter!(ws2, ss, data, T_sim;
-            threshold=0.99, rng=Random.MersenneTwister(5005))
-    @test isfinite(ll2)
-end
-
 @testset "particle_filter: conditional SMC with short reference" begin
     rng = Random.MersenneTwister(5006)
     T_sim = 30
@@ -515,7 +486,8 @@ end
 
         @test result isa BayesianDSGE{Float64}
         @test result.method == :rwmh
-        @test size(result.theta_draws, 1) == 80
+        # :mh discards burn-in (T023): stored draws = n_draws - burnin
+        @test size(result.theta_draws, 1) == 60
         @test isfinite(result.log_marginal_likelihood)
         @test isempty(result.ess_history)
         @test isempty(result.phi_schedule)

--- a/test/coverage/test_dsge_bayes_coverage.jl
+++ b/test/coverage/test_dsge_bayes_coverage.jl
@@ -305,20 +305,23 @@ end
     N = 25
     rng = Random.MersenneTwister(7002)
 
+    # 5-arg signature (#133): pass uniform incoming cumulative weights.
+    uw = fill(-log(N), N)
+
     # Case: uniform log-likelihoods => can jump to phi=1
     log_liks_uniform = fill(0.0, N)
-    phi = M._adaptive_tempering(log_liks_uniform, 0.0, 0.5, N)
+    phi = M._adaptive_tempering(log_liks_uniform, uw, 0.0, 0.5, N)
     @test phi == 1.0
 
     # Case: highly dispersed => needs many small steps
     log_liks_dispersed = randn(rng, N) * 100.0
-    phi2 = M._adaptive_tempering(log_liks_dispersed, 0.0, 0.9, N)
+    phi2 = M._adaptive_tempering(log_liks_dispersed, uw, 0.0, 0.9, N)
     @test phi2 > 0.0
     @test phi2 <= 1.0
 
     # Case: starting from phi_old > 0
     log_liks_mild = randn(rng, N)
-    phi3 = M._adaptive_tempering(log_liks_mild, 0.5, 0.5, N)
+    phi3 = M._adaptive_tempering(log_liks_mild, uw, 0.5, 0.5, N)
     @test phi3 >= 0.5
     @test phi3 <= 1.0
 end

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1547,6 +1547,67 @@ end
     @test MacroEconometricModels._terminal_resample!(state_u, Np, Random.MersenneTwister(1)) == false
 end
 
+# ── E-06 / #134: SMC² PMMH mutation (chunked workspaces, unconditional PF) ──
+
+@testset "_chunk_ranges: contiguous non-overlapping partition of 1:N" begin
+    _cr = MacroEconometricModels._chunk_ranges
+    # Even/uneven splits cover exactly 1:N with no overlap, no threadid() aliasing.
+    for (N, k) in ((100, 4), (101, 4), (7, 3), (10, 1), (5, 5))
+        rgs = _cr(N, k)
+        @test length(rgs) == k
+        @test reduce(vcat, collect.(rgs)) == collect(1:N)   # covers 1:N in order, once each
+        @test maximum(length.(rgs)) - minimum(length.(rgs)) <= 1   # near-equal
+    end
+    # N < k → trailing chunks are empty (no phantom particles)
+    rgs = _cr(3, 8)
+    @test length(rgs) == 8
+    @test count(!isempty, rgs) == 3
+    @test reduce(vcat, collect.(rgs)) == collect(1:3)
+end
+
+@testset "SMC² PMMH recovers the Kalman posterior (linear model)" begin
+    # On a linear model the bootstrap PF is a noisy estimator of the exact Kalman
+    # likelihood, so the redesigned PMMH SMC² kernel must recover the same posterior
+    # as :smc (exact Kalman). Verifies the mutation targets the correct distribution.
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.7, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    sim_data = simulate(sol_true, 120; rng=Random.MersenneTwister(2026))
+    priors = Dict(:ρ => Beta(2, 2))
+    merr = [0.1]
+
+    r_smc = estimate_dsge_bayes(spec, sim_data, [0.5]; priors=priors, method=:smc,
+        observables=[:y], n_smc=300, measurement_error=merr,
+        rng=Random.MersenneTwister(1))
+    r_smc2 = estimate_dsge_bayes(spec, sim_data, [0.5]; priors=priors, method=:smc2,
+        observables=[:y], n_smc=200, n_particles=200, n_mh_steps=2,
+        measurement_error=merr, solver=:gensys,
+        rng=Random.MersenneTwister(101))
+
+    ρ_smc = mean(r_smc.theta_draws[:, 1])
+    ρ_smc2 = mean(r_smc2.theta_draws[:, 1])
+    # Both recover the true ρ region (data posterior ≈ 0.69, well away from prior mean 0.5).
+    @test ρ_smc2 > 0.6
+    # SMC² PMMH agrees with the exact-Kalman SMC reference within MC error (observed ≈ 0.002).
+    @test isapprox(ρ_smc2, ρ_smc; atol=0.05)
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 8: Display, Report, Refs, Plot
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1068,6 +1068,59 @@ end
     end
 end
 
+@testset "RWMH freezes proposal after burn-in and windows the acceptance signal (T038)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 200; rng=Random.MersenneTwister(42))'
+
+    prior = MacroEconometricModels.DSGEPrior(Dict(:ρ => Beta(2, 2));
+        lower=Dict(:ρ => 0.01), upper=Dict(:ρ => 0.99))
+
+    # burnin=300 ≥ 2*adapt_interval ⇒ adaptation fires at 100,150,…,300 then freezes;
+    # n_draws=1500 ≫ burnin so an un-frozen sampler would keep moving the proposal.
+    draws, log_post, acc_rate, diag = MacroEconometricModels._mh_sample(
+        spec, data, [:ρ], prior, [0.5];
+        n_draws=1500, burnin=300, adapt_interval=50,
+        observables=[:y], measurement_error=nothing,
+        solver=:gensys, solver_kwargs=NamedTuple(),
+        rng=Random.MersenneTwister(123))
+
+    # 1. FREEZE: proposal at end of burn-in == proposal at end of run.
+    @test diag.proposal_L_at_burnin ≈ diag.proposal_L
+    @test diag.scale_at_burnin == diag.scale_factor
+
+    # 2. Adaptation actually occurred (so the freeze is meaningful): the burn-in proposal
+    #    has moved away from the initial c2·I.
+    init_L = cholesky(Hermitian((2.38^2) * Matrix{Float64}(I, 1, 1))).L
+    @test !isapprox(diag.proposal_L_at_burnin, init_L)
+
+    # 3. WINDOWED SIGNAL: recorded, in [0,1], and NOT equal to the cumulative signal.
+    @test !isempty(diag.window_acc_history)
+    @test all(0.0 .<= diag.window_acc_history .<= 1.0)
+    @test diag.window_acc_history != diag.cum_acc_history
+
+    # 4. Recovery sanity.
+    @test 0.0 < acc_rate < 1.0
+    @test abs(mean(draws[301:end, 1]) - 0.8) < 0.3
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 5: SMC² (Nested PF inside SMC)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1271,6 +1271,90 @@ end
     end
 end
 
+# ── E-12 / H-12 / #136: theta0 as Dict/NamedTuple + length validation ──
+
+@testset "_resolve_theta0: order-independent Dict/NamedTuple + length validation" begin
+    _rt = MacroEconometricModels._resolve_theta0
+    pnames = [:alpha, :rho, :sigma]                        # sorted prior keys
+
+    # Dict / NamedTuple in scrambled order → values land on the RIGHT parameters.
+    @test _rt(Dict(:sigma => 0.3, :alpha => 0.1, :rho => 0.9), pnames, Float64) == [0.1, 0.9, 0.3]
+    @test _rt((sigma = 0.3, alpha = 0.1, rho = 0.9), pnames, Float64) == [0.1, 0.9, 0.3]
+    # Positional vector (must already be in sorted order) passes through.
+    @test _rt([0.1, 0.9, 0.3], pnames, Float64) == [0.1, 0.9, 0.3]
+    # Type conversion.
+    @test _rt(Dict(:alpha => 0.1, :rho => 0.9, :sigma => 0.3), pnames, Float32) isa Vector{Float32}
+    # Wrong-length positional vector → informative ArgumentError (was a late opaque failure).
+    @test_throws ArgumentError _rt([0.1, 0.9], pnames, Float64)
+    # Dict missing a parameter → ArgumentError.
+    @test_throws ArgumentError _rt(Dict(:alpha => 0.1, :rho => 0.9), pnames, Float64)
+    # Dict with an unknown parameter → ArgumentError.
+    @test_throws ArgumentError _rt(
+        Dict(:alpha => 0.1, :rho => 0.9, :sigma => 0.3, :bogus => 0.0), pnames, Float64)
+end
+
+@testset "estimate_dsge_bayes: accepts Dict theta0, errors on wrong length (#136)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sol = solve(spec; method=:gensys)
+    sim_data = simulate(sol, 100; rng=Random.MersenneTwister(42))
+    priors = Dict(:ρ => Beta(2, 2), :σ => InverseGamma(3.0, 1.0))
+
+    # Dict theta0 in scrambled order runs end-to-end (order-independent).
+    r = estimate_dsge_bayes(spec, sim_data, Dict(:σ => 0.5, :ρ => 0.5);
+        priors=priors, method=:smc, observables=[:y], n_smc=100,
+        rng=Random.MersenneTwister(1))
+    @test r isa BayesianDSGE{Float64}
+    # Wrong-length positional vector errors before sampling.
+    @test_throws ArgumentError estimate_dsge_bayes(spec, sim_data, [0.5];
+        priors=priors, method=:smc, observables=[:y], n_smc=100,
+        rng=Random.MersenneTwister(1))
+    end
+end
+
+# ── E-18 / #142: data orientation resolved by matching n_obs (T×n convention) ──
+
+@testset "_orient_data: orientation by n_obs, not by size comparison" begin
+    _od = MacroEconometricModels._orient_data
+    @test size(_od(reshape(collect(1.0:20), 10, 2), 2, Float64)) == (2, 10)   # T×n → n_obs×T_obs
+    @test size(_od(reshape(collect(1.0:20), 2, 10), 2, Float64)) == (2, 10)    # n×T → as-is
+    A = randn(Random.MersenneTwister(1), 40, 3)
+    @test _od(A, 3, Float64) == _od(permutedims(A), 3, Float64)                 # same internal matrix
+    # Neither dimension equals n_obs → informative ArgumentError (was a silent best-guess).
+    @test_throws ArgumentError _od(randn(3, 100), 1, Float64)
+end
+
+@testset "estimate_dsge_bayes: T×n and n×T give the same likelihood (#142)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sim = simulate(solve(spec; method=:gensys), 100; rng=Random.MersenneTwister(42))  # 100×1 (T×n)
+    priors = Dict(:ρ => Beta(2, 2))
+
+    r_tn = estimate_dsge_bayes(spec, sim, [0.5]; priors=priors, method=:smc,
+        observables=[:y], n_smc=100, rng=Random.MersenneTwister(5))
+    r_nt = estimate_dsge_bayes(spec, permutedims(sim), [0.5]; priors=priors, method=:smc,
+        observables=[:y], n_smc=100, rng=Random.MersenneTwister(5))
+    @test r_tn.log_marginal_likelihood ≈ r_nt.log_marginal_likelihood
+    # A shape where neither dimension equals n_obs errors instead of guessing.
+    @test_throws ArgumentError estimate_dsge_bayes(spec, randn(3, 100), [0.5];
+        priors=priors, method=:smc, observables=[:y], n_smc=50)
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 7: Posterior Analysis
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -231,6 +231,40 @@ end
     @test ws.reference_ancestors === nothing
 end
 
+@testset "Particle-filter likelihood correct under adaptive resampling (#128)" begin
+    # On a small linear-Gaussian state space the Kalman likelihood is exact. The bootstrap PF
+    # log-likelihood must match it even when adaptive resampling SKIPS steps (low threshold):
+    # the ratio-form increment logsumexp(L_t)-logsumexp(L_{t-1}) keeps the carried non-uniform
+    # weights, whereas the pre-fix logsumexp(log g_t)-log N increment biased every skipped step.
+    ns, no, nsh = 2, 1, 1
+    G1 = [0.6 0.0; 0.0 0.4]
+    impact = reshape([1.0, 0.5], ns, nsh)
+    Z = [1.0 1.0]
+    d = [0.0]
+    H = reshape([0.05], no, no)
+    Q = reshape([1.0], nsh, nsh)
+    ss = MacroEconometricModels.DSGEStateSpace{Float64}(G1, impact, Z, d, H, Q)
+    T_obs = 50
+    data = let rng = MersenneTwister(1), x = zeros(ns), dat = zeros(no, T_obs), Hc = sqrt(H[1, 1])
+        for t in 1:T_obs
+            x = G1 * x + impact * randn(rng, nsh)
+            dat[:, t] = Z * x .+ d .+ Hc * randn(rng, no)
+        end
+        dat
+    end
+    ll_kalman = MacroEconometricModels._kalman_loglikelihood(ss, data)
+    N = 2500
+    for thr in (0.1, 0.5, 1.0)   # 0.1 skips most resamples yet must still match Kalman
+        lls = Float64[]
+        for s in 1:50
+            ws = MacroEconometricModels._allocate_pf_workspace(Float64, ns, no, nsh, N)
+            push!(lls, MacroEconometricModels._bootstrap_particle_filter!(
+                ws, ss, data, T_obs; threshold=thr, rng=MersenneTwister(1000 + s)))
+        end
+        @test isapprox(mean(lls), ll_kalman; rtol=0.05)
+    end
+end
+
 @testset "PFWorkspace allocation — order 2" begin
     n_states = 4
     n_obs = 2

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -2123,6 +2123,56 @@ end
     end
 end
 
+@testset "SMC² init likelihoods: threaded chunks == serial (#146 #147)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.7, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sim = simulate(solve(true_spec; method=:gensys), 60; rng=Random.MersenneTwister(3))
+    data = Matrix(reshape(sim[:, 1], 1, :)); T_obs = size(data, 2)
+    merr = [0.4]; N = 12; N_x = 200
+    n_states = spec.n_endog; n_shocks = spec.n_exog
+    npool = max(Threads.nthreads(), 1)
+
+    pf_ll_fn = MacroEconometricModels._build_pf_likelihood_fn(spec, [:ρ], data, [:y],
+        merr, :gensys, NamedTuple(), N_x)
+    thetas = reshape(collect(range(0.55, 0.85; length=N)), 1, N)
+    # Fixed per-particle seeds ⇒ threaded and serial must agree exactly.
+    seeds = UInt64[hash((j, UInt64(0x5EED))) for j in 1:N]
+
+    # THREADED: chunked helper with one PF workspace per chunk.
+    pool = [MacroEconometricModels._allocate_pf_workspace(
+        Float64, n_states, 1, n_shocks, N_x; T_obs=T_obs) for _ in 1:npool]
+    ll_thr = fill(-Inf, N); sols_thr = Vector{Any}(undef, N); fill!(sols_thr, nothing)
+    MacroEconometricModels._smc2_init_likelihoods!(ll_thr, sols_thr, thetas, spec, [:ρ],
+        [:y], merr, :gensys, NamedTuple(), pf_ll_fn, pool, data, T_obs, seeds)
+
+    # SERIAL reference: single workspace, same per-particle seeds and closure.
+    ws = MacroEconometricModels._allocate_pf_workspace(Float64, n_states, 1, n_shocks, N_x; T_obs=T_obs)
+    ll_ser = fill(-Inf, N)
+    for j in 1:N
+        rr = Random.MersenneTwister(seeds[j])
+        ll_ser[j] = pf_ll_fn(Vector{Float64}(thetas[:, j]), ws, rr)
+    end
+
+    @test ll_thr == ll_ser              # bit-identical, thread-count-independent (#146/#147)
+    @test all(isfinite, ll_thr)
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 8: Display, Report, Refs, Plot
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1023,6 +1023,86 @@ end
     end
 end
 
+@testset "Likelihood closure: narrow catch + failure counting (T041)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sol = solve(spec; method=:gensys)
+    good = simulate(sol, 100; rng=Random.MersenneTwister(42))'   # 1×100
+
+    # (a) A genuine bug (dimension mismatch: 2-row data vs 1 observable) PROPAGATES
+    #     rather than being swallowed to -Inf.
+    bad = vcat(good, good)   # 2×100
+    ll_fn_bad = MacroEconometricModels._build_likelihood_fn(spec, [:ρ], bad,
+        [:y], nothing, :gensys, NamedTuple())
+    @test_throws DimensionMismatch ll_fn_bad([0.5])
+
+    # (b) A legitimate indeterminacy is caught, returns -Inf, and is COUNTED.
+    fails = Threads.Atomic{Int}(0); evals = Threads.Atomic{Int}(0)
+    ll_fn = MacroEconometricModels._build_likelihood_fn(spec, [:ρ], good,
+        [:y], nothing, :gensys, NamedTuple(); failures=fails, evals=evals)
+    @test ll_fn([1.5]) == -Inf          # explosive ⇒ !is_determined
+    @test fails[] == 1 && evals[] == 1
+    @test isfinite(ll_fn([0.6]))
+    @test fails[] == 1 && evals[] == 2
+    end
+end
+
+@testset "SMC records and surfaces the likelihood failure count (T041)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sol = solve(spec; method=:gensys)
+    data = simulate(sol, 200; rng=Random.MersenneTwister(7))'
+    # Uniform(0,1.4) prior ⇒ ~29% of particles are explosive (ρ>1) ⇒ many failed evals.
+    priors = Dict(:ρ => Uniform(0.0, 1.4))
+    result = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:smc, observables=[:y],
+        n_smc=200, n_mh_steps=1, rng=Random.MersenneTwister(123))
+    @test result.n_lik_evals > 0
+    @test result.n_failed_draws > 0
+    @test occursin("Failed lik. evals", sprint(show, result))
+    end
+end
+
+@testset "posterior_predictive drops failed draws, no zero-fill (T041)" begin
+    # NOTE: not wrapped in _suppress_warnings — @test_warn must see the "dropped" @warn.
+    spec = _suppress_warnings() do
+        s = @dsge begin
+            parameters: ρ = 0.5, σ = 0.5
+            endogenous: y
+            exogenous: ε
+            y[t] = ρ * y[t-1] + σ * ε[t]
+            steady_state = [0.0]
+        end
+        compute_steady_state(s)
+    end
+    sol, ss = MacroEconometricModels._build_solution_at_theta(spec, [:ρ], [0.5],
+        [:y], nothing, :gensys, NamedTuple())
+    # Half the draws are explosive (ρ=1.5, indeterminate ⇒ dropped), half valid (ρ=0.5).
+    n = 40
+    td = reshape(vcat(fill(0.5, 20), fill(1.5, 20)), 40, 1)
+    prior = MacroEconometricModels.DSGEPrior{Float64}([:ρ], [Uniform(0.0, 2.0)], [0.0], [2.0])
+    post = BayesianDSGE{Float64}(td, zeros(n), [:ρ], prior, 0.0, :smc, 0.5,
+        Float64[], Float64[], spec, sol, ss)   # 12-arg compat ctor
+    Y = @test_warn r"dropped" posterior_predictive(post, 30; T_periods=25,
+        rng=Random.MersenneTwister(9))
+    @test size(Y, 1) < 30                                    # dropped, not zero-filled to 30
+    @test all(any(!iszero, Y[s, :, :]) for s in 1:size(Y, 1))   # no zero path survived
+end
+
 @testset "SMC with Kalman: AR(1) recovery" begin
     _suppress_warnings() do
     rng = Random.MersenneTwister(42)

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1198,6 +1198,40 @@ end
     end
 end
 
+@testset "SMC prior init errors on exhausted retries (T051 #150)" begin
+    _suppress_warnings() do
+        spec = @dsge begin
+            parameters: ρ = 0.5, σ = 0.5
+            endogenous: y
+            exogenous: ε
+            y[t] = ρ * y[t-1] + σ * ε[t]
+            steady_state = [0.0]
+        end
+        spec = compute_steady_state(spec)
+        sol = solve(spec; method=:gensys)
+        data = simulate(sol, 50; rng=Random.MersenneTwister(7))'  # n_obs × T
+
+        # Prior support (Normal(5.0, 0.01)) lies entirely OUTSIDE the [0.01, 0.99] bounds →
+        # every draw is rejected → the initializer must fail loudly, not substitute a midpoint.
+        bad_prior = MacroEconometricModels.DSGEPrior(
+            Dict(:ρ => Normal(5.0, 0.01));
+            lower=Dict(:ρ => 0.01), upper=Dict(:ρ => 0.99))
+
+        err = try
+            MacroEconometricModels._smc_sample(spec, data, [:ρ], bad_prior, [0.5];
+                n_smc=4, observables=[:y], solver=:gensys,
+                rng=Random.MersenneTwister(123))
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        @test occursin("ρ", msg)     # names the offending parameter
+        @test occursin("100", msg)   # names the rejection count
+    end
+end
+
 @testset "SMC tempering: max_stages guard (#145 T046)" begin
     _suppress_warnings() do
     spec = @dsge begin

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -416,12 +416,11 @@ end
     @test d2[1] == spec_ss.steady_state[1]
     @test d2[2] == spec_ss.steady_state[3]
 
-    # H should be positive definite (default 1e-4 * I)
+    # H defaults to ZERO measurement error (T042); n_obs=2 ≤ n_shocks=3, no singularity.
     @test size(H) == (2, 2)
-    @test H[1, 1] > 0.0
-    @test H[2, 2] > 0.0
+    @test all(iszero, H)
+    @test H == zeros(2, 2)
     @test H[1, 2] == 0.0
-    @test H ≈ 1e-4 * I(2)
 
     # Error: unknown observable
     @test_throws ArgumentError MacroEconometricModels._build_observation_equation(
@@ -454,6 +453,58 @@ end
     # Wrong length measurement error
     @test_throws ArgumentError MacroEconometricModels._build_observation_equation(
         spec, [:y, :c], [0.1])
+end
+
+@testset "Stochastic singularity & auto measurement error (T042)" begin
+    spec1 = _suppress_warnings() do
+        @dsge begin
+            parameters: rho = 0.5
+            endogenous: y, k
+            exogenous: eps
+            y[t] = rho * y[t-1] + eps[t]
+            k[t] = 0.5 * k[t-1] + y[t]
+            steady_state = [0.0, 0.0]
+        end
+    end
+
+    _suppress_warnings() do
+        # (a) Default zero ME when n_obs ≤ n_shocks (2 obs, 2 shocks).
+        spec2 = @dsge begin
+            parameters: rho = 0.8
+            endogenous: y, c
+            exogenous: eps_y, eps_c
+            y[t] = rho * y[t-1] + eps_y[t]
+            c[t] = rho * c[t-1] + eps_c[t]
+        end
+        _, _, H0 = MacroEconometricModels._build_observation_equation(spec2, [:y, :c], nothing)
+        @test all(iszero, H0)
+
+        # (b) Builder throws on stochastic singularity (2 obs > 1 shock).
+        @test_throws MacroEconometricModels.StochasticSingularityError MacroEconometricModels._build_observation_equation(
+            spec1, [:y, :k], nothing)
+
+        # (c) Explicit vector ME with n_obs>n_shocks does NOT throw.
+        _, _, Hv = MacroEconometricModels._build_observation_equation(spec1, [:y, :k], [0.01, 0.01])
+        @test Hv ≈ diagm([1e-4, 1e-4])
+
+        # (d) Entry-point singularity check fires before sampling.
+        spec1c = compute_steady_state(spec1)
+        data1 = simulate(solve(spec1c; method=:gensys), 50; rng=Random.MersenneTwister(1))
+        @test_throws MacroEconometricModels.StochasticSingularityError estimate_dsge_bayes(
+            spec1c, data1, [0.5]; priors=Dict(:rho => Beta(2, 2)),
+            method=:smc, observables=[:y, :k], measurement_error=nothing,
+            n_smc=20, rng=Random.MersenneTwister(0))
+    end
+
+    # (e) :auto scales per-observable to √(0.1·var) and warns (outside suppression).
+    dm = reshape(Float64[1.0, 2.0, 3.0, 4.0, 5.0], 1, 5)
+    me = @test_logs (:warn,) match_mode=:any MacroEconometricModels._resolve_measurement_error(
+        :auto, dm, [:y])
+    @test me[1] ≈ sqrt(0.1 * var(dm[1, :]))
+    # per-observable scaling: a higher-variance series gets a larger SD
+    dm2 = [ones(1, 5); 10.0 .* Float64[1.0 2.0 3.0 4.0 5.0]]
+    me2 = MacroEconometricModels._resolve_measurement_error(:auto, dm2, [:a, :b])
+    @test me2[2] > me2[1]
 end
 
 @testset "Build state space from DSGESolution" begin
@@ -1273,8 +1324,10 @@ end
     sol = solve(spec; method=:gensys)
     data_mat = simulate(sol, 50; rng=Random.MersenneTwister(42))'
 
+    # Bootstrap PF needs nonzero measurement error to weight particles (T042 default is
+    # zero ME); [0.01] reproduces the former 1e-4·I default (0.01² = 1e-4).
     pf_ll_fn = MacroEconometricModels._build_pf_likelihood_fn(spec, [:ρ], data_mat,
-        [:y], nothing, :gensys, NamedTuple(), 100)
+        [:y], [0.01], :gensys, NamedTuple(), 100)
 
     ws = MacroEconometricModels._allocate_pf_workspace(Float64, 1, 1, 1, 100; T_obs=50)
     rng = Random.MersenneTwister(123)
@@ -2211,8 +2264,10 @@ end
         :ρ => Beta(2, 2),
         :α => Normal(0.3, 0.1)
     )
+    # 1 shock but 2 observables ⇒ n_obs>n_shocks: must supply explicit ME (T042).
     result = estimate_dsge_bayes(spec, data, [0.5, 0.3];
         priors=priors, method=:smc, observables=[:y, :k],
+        measurement_error=[0.01, 0.01],
         n_smc=300, n_mh_steps=1,
         rng=Random.MersenneTwister(123))
 
@@ -2485,7 +2540,9 @@ end
     data_sim = simulate(sol, 50; rng=Random.MersenneTwister(1))
     data = Matrix{Float64}(data_sim')  # n_obs x T_obs
 
-    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], nothing)
+    # Bootstrap PF needs nonzero measurement error (T042 default is zero ME);
+    # [0.01] reproduces the former 1e-4·I default.
+    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], [0.01])
     nlss = MacroEconometricModels._build_nonlinear_state_space(sol, Z, d, H)
 
     nx = length(sol.state_indices)
@@ -2521,7 +2578,8 @@ end
     data_sim = simulate(sol, T_obs; rng=Random.MersenneTwister(1))
     data = Matrix{Float64}(data_sim')
 
-    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], nothing)
+    # Bootstrap PF/CSMC need nonzero measurement error (T042 default is zero ME).
+    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], [0.01])
     nlss = MacroEconometricModels._build_nonlinear_state_space(sol, Z, d, H)
 
     nx = length(sol.state_indices)
@@ -2568,8 +2626,9 @@ end
     data_sim = simulate(sol_lin, T_obs; rng=Random.MersenneTwister(1))
     data = Matrix{Float64}(data_sim')
 
-    # Kalman log-likelihood
-    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], nothing)
+    # Kalman log-likelihood. Bootstrap PF needs nonzero measurement error (T042 default
+    # is zero ME); use the same H for both so the PF-vs-Kalman comparison is fair.
+    Z, d, H = MacroEconometricModels._build_observation_equation(spec, [:y], [0.01])
     ss = MacroEconometricModels._build_state_space(sol_lin, Z, d, H)
     ll_kalman = MacroEconometricModels._kalman_loglikelihood(ss, data)
 

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -914,18 +914,17 @@ end
 @testset "Adaptive tempering bisection" begin
     N = 100
     log_liks = randn(Random.MersenneTwister(123), N)
+    log_weights = fill(-log(N), N)          # uniform incoming weights (5-arg signature, #133)
     phi_old = 0.0
     ess_target = 0.5
 
-    phi_new = MacroEconometricModels._adaptive_tempering(log_liks, phi_old, ess_target, N)
+    phi_new = MacroEconometricModels._adaptive_tempering(log_liks, log_weights, phi_old, ess_target, N)
     @test phi_new > phi_old
     @test phi_new <= 1.0
 
-    # Check ESS at this phi
-    delta_phi = phi_new - phi_old
-    inc_log_w = delta_phi .* log_liks
-    inc_log_w .-= MacroEconometricModels._logsumexp(inc_log_w) - log(N)
-    w = exp.(inc_log_w)
+    # ESS of the cumulative weights at this phi (reduces to incremental under uniform incoming)
+    lw = log_weights .+ (phi_new - phi_old) .* log_liks
+    w = exp.(lw .- MacroEconometricModels._logsumexp(lw))
     w ./= sum(w)
     ess = 1.0 / sum(abs2, w)
     @test abs(ess - ess_target * N) < 5.0
@@ -1435,6 +1434,117 @@ end
     # miss by ≈ 2.5 and fail this bound.
     @test isapprox(ml_smc, ml_mh; atol=2.0)
     end
+end
+
+# ── E-08 / #131: SMC marginal-likelihood increment under non-uniform weights ──
+
+@testset "SMC log marginal likelihood: ratio increment (resample-invariant)" begin
+    # The per-stage ML increment must be logsumexp(lw+inc)−logsumexp(lw), the
+    # weighted-average tempering factor, NOT logsumexp(inc)−log N (valid only when
+    # incoming weights are uniform). A low ess_target takes few, large tempering
+    # steps that leave many stages *un*-resampled (non-uniform incoming weights),
+    # while a high ess_target resamples almost every stage. Both configurations
+    # estimate the *same* marginal likelihood, so their log-ML must agree within
+    # Monte Carlo error. Pre-fix (uniform form) the two configs disagreed by ≈0.36;
+    # the ratio form brings them to ≈0.05 (well inside MC noise).
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 1.0
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.7, σ = 1.0
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    sim_data = simulate(sol_true, 150; rng=Random.MersenneTwister(99))
+    priors = Dict(:ρ => Beta(2, 2), :σ => Gamma(2, 0.5))
+
+    run_cfg(ess) = [marginal_likelihood(estimate_dsge_bayes(spec, sim_data, [0.5, 1.0];
+                        priors=priors, method=:smc, observables=[:y], n_smc=400,
+                        ess_target=ess, rng=Random.MersenneTwister(sd)))
+                    for sd in 1:6]
+
+    ml_lo = run_cfg(0.50)   # few, large steps → non-resampled stages
+    ml_hi = run_cfg(0.90)   # many, small steps → resamples ≈ every stage
+    @test all(isfinite, ml_lo)
+    @test all(isfinite, ml_hi)
+    @test all(<(0), ml_lo)
+    # Resample-invariance of the marginal-likelihood estimate. Documented MC
+    # tolerance 0.3; the pre-fix uniform form biased ml_lo by ≈0.36 and fails this.
+    @test isapprox(sum(ml_lo)/6, sum(ml_hi)/6; atol=0.3)
+    end
+end
+
+# ── E-10 / #133: adaptive tempering targets ESS of the CUMULATIVE weights ──
+
+@testset "_adaptive_tempering: ESS on cumulative weights (no overshoot)" begin
+    lse = MacroEconometricModels._logsumexp
+    N = 300
+    rng = Random.MersenneTwister(7)
+    log_liks = 1.5 .* randn(rng, N)
+    log_weights = 0.7 .* randn(rng, N)      # non-uniform incoming cumulative weights
+    phi_old = 0.3
+    ess_target = 0.5
+
+    ess_cum(phi) = (lw = log_weights .+ (phi - phi_old) .* log_liks;
+                    w = exp.(lw .- lse(lw)); 1.0 / sum(abs2, w))
+    ess_inc(phi) = (inc = (phi - phi_old) .* log_liks;
+                    w = exp.(inc .- lse(inc)); 1.0 / sum(abs2, w))
+
+    # Valid bracket: cumulative ESS starts above target and drops below it by φ=1.
+    @test ess_cum(phi_old) > ess_target * N
+    @test ess_cum(1.0) < ess_target * N
+
+    phi_new = MacroEconometricModels._adaptive_tempering(
+        log_liks, log_weights, phi_old, ess_target, N)
+    @test phi_old < phi_new <= 1.0
+    # Realized ESS on the CUMULATIVE weights hits the target (bisection tol ≈1 in ESS units).
+    @test isapprox(ess_cum(phi_new), ess_target * N; atol=2.0)
+    # The uniform-base (incremental-only) ESS at this φ is materially different — the old
+    # computation would have chosen a different φ and overshot the cumulative ESS target.
+    @test abs(ess_inc(phi_new) - ess_cum(phi_new)) > 5.0
+end
+
+# ── E-09 / #132: terminal resample → stored SMC draws are equal-weighted ──
+
+@testset "_terminal_resample!: unweighted quantiles match weighted pre-resample set" begin
+    lse = MacroEconometricModels._logsumexp
+    np, Np = 2, 500
+    rng = Random.MersenneTwister(11)
+    theta = randn(rng, np, Np); theta[1, :] .+= 3.0
+    lw0 = 1.2 .* randn(rng, Np)              # deliberately non-uniform terminal weights
+    state = MacroEconometricModels.SMCState{Float64}(
+        copy(theta), copy(lw0), randn(rng, Np), randn(rng, Np),
+        Float64[0.0, 1.0], Float64[], Float64[], 0.0,
+        MacroEconometricModels.PFWorkspace{Float64}[], Matrix{Float64}(I, np, np))
+
+    # weighted median of param 1 on the pre-resample particle set
+    w = exp.(lw0 .- lse(lw0))
+    perm = sortperm(theta[1, :]); cw = cumsum(w[perm]); cw ./= cw[end]
+    wq50_before = theta[1, perm][findfirst(>=(0.5), cw)]
+
+    did = MacroEconometricModels._terminal_resample!(state, Np, Random.MersenneTwister(123))
+    @test did                                                    # non-uniform → resampled
+    weights_after = exp.(state.log_weights .- lse(state.log_weights))
+    @test all(≈(1 / Np), weights_after)                          # stored weights uniform
+    # plain (unweighted) median of resampled draws ≈ weighted median of the original set
+    @test isapprox(quantile(state.theta_particles[1, :], 0.5), wq50_before; atol=0.3)
+
+    # No-op when weights are already uniform (e.g. the final stage resampled) — no double resample.
+    state_u = MacroEconometricModels.SMCState{Float64}(
+        copy(theta), fill(-log(Float64(Np)), Np), zeros(Np), zeros(Np),
+        Float64[0.0, 1.0], Float64[], Float64[], 0.0,
+        MacroEconometricModels.PFWorkspace{Float64}[], Matrix{Float64}(I, np, np))
+    @test MacroEconometricModels._terminal_resample!(state_u, Np, Random.MersenneTwister(1)) == false
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1389,6 +1389,33 @@ end
     end
 end
 
+@testset "posterior_summary: quantiles equal Statistics.quantile (#144)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sim_data = simulate(solve(spec; method=:gensys), 200; rng=rng)
+    priors = Dict(:ρ => Beta(2, 2))
+    result = estimate_dsge_bayes(spec, sim_data, [0.5];
+        priors=priors, method=:smc, observables=[:y],
+        n_smc=300, rng=Random.MersenneTwister(1))
+
+    ps = posterior_summary(result)
+    d = result.theta_draws[:, 1]
+    # Reported median/CI bounds are interpolated Statistics.quantile of the (unweighted,
+    # post-terminal-resample) draws — the old order-statistic indexing did not match.
+    @test ps[:ρ][:median]   ≈ quantile(d, 0.5)
+    @test ps[:ρ][:ci_lower] ≈ quantile(d, 0.025)
+    @test ps[:ρ][:ci_upper] ≈ quantile(d, 0.975)
+    end
+end
+
 @testset "marginal_likelihood" begin
     _suppress_warnings() do
     spec = @dsge begin

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1198,6 +1198,78 @@ end
     end
 end
 
+@testset "SMC tempering: max_stages guard (#145 T046)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 200; rng=Random.MersenneTwister(42))'
+    prior = MacroEconometricModels.DSGEPrior(Dict(:ρ => Beta(2, 2));
+        lower=Dict(:ρ => 0.01), upper=Dict(:ρ => 0.99))
+    # An informative 200-obs AR(1) SMC needs many tempering stages; capping at 2 must raise.
+    @test_throws ErrorException MacroEconometricModels._smc_sample(
+        spec, data, [:ρ], prior, [0.5];
+        n_smc=100, n_mh_steps=1, ess_target=0.5, observables=[:y],
+        solver=:gensys, max_stages=2, rng=Random.MersenneTwister(123))
+    end
+end
+
+@testset "_check_tempering_progress: min_dphi + max_stages guards (#145 T046)" begin
+    # A degenerate step Δφ < min_dphi while φ < 1 raises (stall).
+    @test_throws ErrorException MacroEconometricModels._check_tempering_progress(
+        3, 500, 0.5, 0.5 + 1e-9, 1e-6)
+    # Exceeding the stage cap raises.
+    @test_throws ErrorException MacroEconometricModels._check_tempering_progress(
+        501, 500, 0.9, 0.95, 1e-6)
+    # A legitimate final jump to exactly φ=1 is never flagged, even if the step is small.
+    @test MacroEconometricModels._check_tempering_progress(10, 500, 0.9999, 1.0, 1e-6) === nothing
+    # Normal within-schedule progress does not raise.
+    @test MacroEconometricModels._check_tempering_progress(5, 500, 0.3, 0.5, 1e-6) === nothing
+end
+
+@testset "SMC² tempering: max_stages guard (#145 T046)" begin
+    FAST && return
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 100; rng=Random.MersenneTwister(42))'
+    prior = MacroEconometricModels.DSGEPrior(Dict(:ρ => Beta(2, 2));
+        lower=Dict(:ρ => 0.01), upper=Dict(:ρ => 0.99))
+    @test_throws ErrorException MacroEconometricModels._smc2_sample(
+        spec, data, [:ρ], prior, [0.5];
+        n_smc=40, n_particles=20, n_mh_steps=1, ess_target=0.5,
+        observables=[:y], measurement_error=[0.5], solver=:gensys,
+        max_stages=2, rng=Random.MersenneTwister(5))
+    end
+end
+
 @testset "Adaptive RWMH: AR(1) recovery" begin
     _suppress_warnings() do
     rng = Random.MersenneTwister(42)

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -526,6 +526,49 @@ end
     @test ll_correct > ll_wrong  # correct model should have higher log-likelihood
 end
 
+@testset "Kalman diffuse init: scale-invariant under a unit root (T040)" begin
+    # Transition with one unit root (random walk) + one stationary direction.
+    G1 = [1.0 0.0; 0.0 0.6]
+    impact = [0.4 0.0; 0.0 0.3]
+    Z = Matrix{Float64}(I, 2, 2)
+    d = zeros(2)
+    H = 1e-6 * Matrix{Float64}(I, 2, 2)
+    Q = Matrix{Float64}(I, 2, 2)
+
+    x = zeros(2, 200); rng = Random.MersenneTwister(20240709)
+    for t in 2:200; x[:, t] = G1 * x[:, t-1] + impact * randn(rng, 2); end
+    data = x
+
+    ss = MacroEconometricModels.DSGEStateSpace{Float64}(G1, impact, Z, d, H, Q)
+    ll = _suppress_warnings() do
+        MacroEconometricModels._kalman_loglikelihood(ss, data)
+    end
+    @test isfinite(ll)
+
+    # Rescale ONLY the nonstationary STATE direction (Z compensates), so the OBSERVED
+    # process is unchanged ⇒ the likelihood must be (near-)invariant. G1 diagonal ⇒
+    # D*G1*Dinv == G1, so the transition is unchanged.
+    c = 100.0; D = [c 0.0; 0.0 1.0]; Dinv = [1/c 0.0; 0.0 1.0]
+    ss_scaled = MacroEconometricModels.DSGEStateSpace{Float64}(G1, D*impact, Z*Dinv, d, H, Q)
+    ll_scaled = _suppress_warnings() do
+        MacroEconometricModels._kalman_loglikelihood(ss_scaled, data)
+    end
+    # κ=1e6 diffuse init leaves an O(log c)≈4.6 residual; P0=10*I blows up (fails atol=15).
+    @test isapprox(ll, ll_scaled; atol=15.0)
+end
+
+@testset "Kalman init: non-stability error propagates, not swallowed (T040)" begin
+    G1 = fill(0.5, 1, 1)             # stationary ⇒ takes the solve_lyapunov branch
+    impact_bad = zeros(2, 1)         # 2 rows vs n_states=1 ⇒ solve_lyapunov throws
+    Z = ones(1, 1); d = zeros(1); H = fill(1e-6, 1, 1); Q = ones(1, 1)
+    ss_bad = MacroEconometricModels.DSGEStateSpace{Float64}(G1, impact_bad, Z, d, H, Q)
+    data = reshape(randn(Random.MersenneTwister(1), 20), 1, 20)
+    # Old code swallowed this into P0=10I and returned a finite ll; now it propagates.
+    @test_throws ArgumentError _suppress_warnings() do
+        MacroEconometricModels._kalman_loglikelihood(ss_bad, data)
+    end
+end
+
 @testset "Kalman loglikelihood: 2D with missing data" begin
     Random.seed!(123)
 

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1355,6 +1355,88 @@ end
     end
 end
 
+# ── E-04 / #130: RWMH marginal likelihood = Geweke (1999) modified harmonic mean ──
+
+@testset "_geweke_mhm: recovers analytic Gaussian marginal likelihood" begin
+    # If the posterior is exactly N(μ, Σ) and the kernel is c·N(θ;μ,Σ), then the
+    # marginal likelihood (integral of the kernel) equals c, so log ML = log c.
+    # The MHM estimator applied to draws from N(μ,Σ) must recover log c — this is
+    # the precise, deterministic check that the estimator (not just "some finite
+    # number") is correct.
+    rng = Random.MersenneTwister(20260708)
+    μ = [0.5, -0.3]
+    Σ = [0.04 0.01; 0.01 0.09]
+    mvn = MvNormal(μ, Σ)
+    S = 20_000
+    draws = Matrix(rand(rng, mvn, S)')          # S×d
+    log_c = -50.0
+    kernel = [log_c + logpdf(mvn, draws[s, :]) for s in 1:S]
+
+    est = MacroEconometricModels._geweke_mhm(draws, kernel)
+    @test isfinite(est)
+    @test isapprox(est, log_c; atol=0.3)         # observed ≈ -49.99
+
+    # Truncation fraction p should not materially move the estimate (Geweke's point).
+    est_p9 = MacroEconometricModels._geweke_mhm(draws, kernel; p=0.9)
+    est_p1 = MacroEconometricModels._geweke_mhm(draws, kernel; p=0.1)
+    @test isapprox(est_p9, log_c; atol=0.4)
+    @test isapprox(est_p1, log_c; atol=0.4)
+end
+
+@testset "_geweke_mhm: short-chain / degenerate guards return NaN" begin
+    _suppress_warnings() do
+        # S < 10·d → NaN, not a silently wrong number.
+        short = randn(Random.MersenneTwister(1), 5, 2)
+        @test isnan(MacroEconometricModels._geweke_mhm(short, fill(-1.0, 5)))
+        # No finite kernel value → NaN.
+        big = randn(Random.MersenneTwister(2), 100, 1)
+        @test isnan(MacroEconometricModels._geweke_mhm(big, fill(-Inf, 100)))
+    end
+end
+
+@testset "marginal_likelihood: :mh MHM agrees with :smc (not max log posterior)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    sim_data = simulate(sol_true, 200; rng=Random.MersenneTwister(2024))
+
+    priors = Dict(:ρ => Beta(2, 2))
+    r_smc = estimate_dsge_bayes(spec, sim_data, [0.5]; priors=priors, method=:smc,
+        observables=[:y], n_smc=400, rng=Random.MersenneTwister(11))
+    r_mh = estimate_dsge_bayes(spec, sim_data, [0.5]; priors=priors, method=:mh,
+        observables=[:y], n_draws=6000, burnin=2000, rng=Random.MersenneTwister(12))
+
+    ml_smc = marginal_likelihood(r_smc)
+    ml_mh  = marginal_likelihood(r_mh)
+    @test isfinite(ml_smc)
+    @test isfinite(ml_mh)
+    # Regression against the old behaviour: the estimator is a genuine evidence
+    # estimate strictly below the max log posterior kernel (the peaked-posterior
+    # Occam factor), NOT `maximum(log_posterior)` (≈ -128.4 here) as before.
+    @test ml_mh < maximum(r_mh.log_posterior)
+    # SMC (tempering path) and MHM estimate the same log marginal likelihood and
+    # agree within a documented Monte Carlo tolerance: the observed gap is ≈ 0.5
+    # (within SMC's own ≈ 0.5 cross-seed spread); the old max-log-posterior would
+    # miss by ≈ 2.5 and fail this bound.
+    @test isapprox(ml_smc, ml_mh; atol=2.0)
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 8: Display, Report, Refs, Plot
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -789,56 +789,6 @@ end
     @test rel_error < 0.15
 end
 
-@testset "Auxiliary particle filter" begin
-    Random.seed!(300)
-
-    # Same AR(1) setup
-    rho = 0.8
-    sigma_eps = 0.5
-    sigma_me = 0.1
-    T_sim = 150
-
-    x = zeros(T_sim)
-    y = zeros(T_sim)
-    for t in 2:T_sim
-        x[t] = rho * x[t-1] + sigma_eps * randn()
-    end
-    for t in 1:T_sim
-        y[t] = x[t] + sigma_me * randn()
-    end
-
-    G1 = fill(rho, 1, 1)
-    impact = fill(sigma_eps, 1, 1)
-    Z = ones(1, 1)
-    d = zeros(1)
-    H = fill(sigma_me^2, 1, 1)
-    Q = ones(1, 1)
-
-    ss = MacroEconometricModels.DSGEStateSpace{Float64}(G1, impact, Z, d, H, Q)
-    data = reshape(y, 1, T_sim)
-
-    # Kalman log-likelihood
-    ll_kalman = MacroEconometricModels._kalman_loglikelihood(ss, data)
-
-    # APF log-likelihood
-    N_particles = 500
-    n_runs = 10
-    ll_apf_runs = zeros(n_runs)
-
-    for r in 1:n_runs
-        ws = MacroEconometricModels._allocate_pf_workspace(Float64, 1, 1, 1, N_particles)
-        ll_apf_runs[r] = MacroEconometricModels._auxiliary_particle_filter!(
-            ws, ss, data, T_sim; rng=Random.MersenneTwister(r * 2000))
-    end
-
-    ll_apf_mean = mean(ll_apf_runs)
-
-    @test isfinite(ll_apf_mean)
-    # APF should be finite and in the right ballpark
-    # APF likelihood estimate can differ from Kalman due to the two-stage structure
-    # but should still be a reasonable finite value
-    @test ll_apf_mean < 0.0  # log-likelihood should be negative
-end
 
 @testset "Conditional SMC" begin
     Random.seed!(400)

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -1608,6 +1608,109 @@ end
     end
 end
 
+# ── E-11 / #135: SMC² N_x adaptation on estimator variance + exchange step ──
+
+@testset "_pf_estimator_variance: estimator noise, not posterior spread (#135)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.7, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    sim = simulate(sol_true, 80; rng=Random.MersenneTwister(7))
+    data = Matrix(reshape(sim[:, 1], 1, :))          # n_obs × T_obs
+    T_obs = size(data, 2)
+    merr = [0.4]
+    n_states = spec.n_endog; n_shocks = spec.n_exog
+    mkpool(N_x, k=1) = [MacroEconometricModels._allocate_pf_workspace(
+        Float64, n_states, 1, n_shocks, N_x; T_obs=T_obs) for _ in 1:k]
+
+    # A DIFFUSE θ-population: ρ ranges widely, so the likelihood level varies a lot
+    # across particles ⇒ var(ll across θ) is large (this is what the OLD trigger fired on).
+    diffuse = reshape(collect(range(0.2, 0.9; length=40)), 1, 40)
+    rng = Random.MersenneTwister(123)
+
+    est400 = MacroEconometricModels._pf_estimator_variance(
+        spec, [:ρ], diffuse, [:y], merr, :gensys, NamedTuple(), mkpool(400),
+        data, T_obs, rng; n_probe=10, n_rep=3)
+    est50 = MacroEconometricModels._pf_estimator_variance(
+        spec, [:ρ], diffuse, [:y], merr, :gensys, NamedTuple(), mkpool(50),
+        data, T_obs, rng; n_probe=10, n_rep=3)
+
+    # var(ll across θ) — the OLD (wrong) trigger quantity — on the same diffuse set.
+    ws = mkpool(400)[1]; lls = Float64[]
+    for i in 1:size(diffuse, 2)
+        rr = Random.MersenneTwister(hash((:av, i)))
+        ll = MacroEconometricModels._solve_and_run_pf(
+            spec, [:ρ], diffuse[:, i], [:y], merr, :gensys, NamedTuple(),
+            ws, data, T_obs, rr)
+        isfinite(ll) && push!(lls, ll)
+    end
+    var_across = var(lls)
+
+    @test var_across > 10                 # OLD trigger (threshold 10) would double N_x here
+    @test est400 < 3                      # NEW estimator-variance trigger does NOT (Chopin ≈1–3)
+    @test est50 > est400                  # estimator variance falls with more inner particles
+    # Decision: on this diffuse-but-well-estimated posterior, N_x stays put (no spurious doubling).
+    @test MacroEconometricModels._adapt_n_particles(400, est400, 3.0) == 400
+    end
+end
+
+@testset "_exchange_step!: recomputes all θ-likelihoods at the new N_x (#135)" begin
+    _suppress_warnings() do
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.7, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sim = simulate(solve(true_spec; method=:gensys), 60; rng=Random.MersenneTwister(3))
+    data = Matrix(reshape(sim[:, 1], 1, :)); T_obs = size(data, 2)
+    merr = [0.4]; N = 20; N_x = 200
+    n_states = spec.n_endog; n_shocks = spec.n_exog
+    npool = max(Threads.nthreads(), 1)
+    pool = [MacroEconometricModels._allocate_pf_workspace(
+        Float64, n_states, 1, n_shocks, N_x; T_obs=T_obs) for _ in 1:npool]
+
+    thetas = reshape(collect(range(0.55, 0.85; length=N)), 1, N)
+    SENTINEL = -1.0e5
+    state = MacroEconometricModels.SMCState{Float64}(
+        copy(thetas), fill(-log(Float64(N)), N),
+        fill(SENTINEL, N), zeros(N),          # stale (old-N_x) sentinel likelihoods
+        Float64[0.0, 1.0], Float64[], Float64[], 0.0,
+        MacroEconometricModels.PFWorkspace{Float64}[], Matrix{Float64}(I, 1, 1))
+
+    MacroEconometricModels._exchange_step!(
+        state, spec, [:ρ], [:y], merr, :gensys, NamedTuple(),
+        pool, data, T_obs, Random.MersenneTwister(99))
+
+    @test all(isfinite, state.log_likelihoods)          # all recomputed to finite values
+    @test all(state.log_likelihoods .!= SENTINEL)       # no stale (old-N_x) estimate remains
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Section 8: Display, Report, Refs, Plot
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3337,4 +3337,44 @@ end
     @test !(d_eff[1] ≈ 0.0)
 end
 
+@testset "Posterior-mean solve failure falls back to highest-posterior draw (T044)" begin
+    _suppress_warnings() do
+    # Forward-looking model: a_ ≤ 0.9 determinate, a_ ≥ 1.2 indeterminate (verified).
+    spec = @dsge begin
+        parameters: a_ = 0.5, s = 0.5
+        endogenous: y
+        exogenous: eps
+        y[t] = a_ * y[t+1] + s * eps[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    prior = MacroEconometricModels.DSGEPrior{Float64}([:a_], [Uniform(0.0, 3.0)], [0.0], [3.0])
+
+    # Mean of [0.5, 1.6, 1.7] = 1.27 is INDETERMINATE ⇒ fall back to the highest-posterior
+    # draw (argmax log-posterior = index 1 ⇒ a_=0.5, determinate). The whole call must still
+    # return a usable BayesianDSGE rather than erroring after sampling.
+    result = MacroEconometricModels._mh_to_bayesian_dsge(
+        reshape([0.5, 1.6, 1.7], 3, 1), [5.0, 1.0, 0.5], 0.4, prior, [:a_],
+        spec, [:y], nothing, :gensys, NamedTuple())
+    @test result isa BayesianDSGE{Float64}
+    @test result.solved_at == :highest_posterior_draw
+    @test is_determined(result.solution)
+    @test occursin("Solution built at", sprint(show, result))
+
+    # Control: a determinate mean stays :posterior_mean.
+    result2 = MacroEconometricModels._mh_to_bayesian_dsge(
+        reshape([0.5, 0.6, 0.7], 3, 1), [1.0, 2.0, 3.0], 0.4, prior, [:a_],
+        spec, [:y], nothing, :gensys, NamedTuple())
+    @test result2.solved_at == :posterior_mean
+    @test is_determined(result2.solution)
+
+    # Shared helper directly (SMC path uses the same seam).
+    sol, ss, tag = MacroEconometricModels._build_solution_mean_or_hpd(
+        spec, [:a_], [1.5], reshape([0.5, 1.5], 2, 1), [3.0, 0.1],
+        [:y], nothing, :gensys, NamedTuple())
+    @test tag == :highest_posterior_draw
+    @test is_determined(sol)
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_dsge.jl
+++ b/test/dsge/test_dsge.jl
@@ -1136,6 +1136,63 @@ end
     end
 end
 
+@testset "IRF matching: SEs respond to target IRF covariance Ω (T039)" begin
+    _suppress_warnings() do
+        rng = Random.MersenneTwister(2039)
+        T_obs = 300; y = zeros(T_obs)
+        for t in 2:T_obs; y[t] = 0.8*y[t-1] + randn(rng); end
+        Y = reshape(y, :, 1)
+        spec = @dsge begin
+            parameters: ρ = 0.5
+            endogenous: y
+            exogenous: ε
+            y[t] = ρ * y[t-1] + ε[t]
+        end
+        H = 10
+        vm = estimate_var(Y, 4); Random.seed!(7)
+        base = irf(vm, H; method=:cholesky, ci_type=:bootstrap, reps=200)
+        vals = base.values; d = base._draws
+        dev  = d .- reshape(vals, 1, size(vals)...)
+        # Two targets with IDENTICAL point IRFs but bootstrap draws scaled by 0.5 vs 2.0.
+        mk(scale) = MacroEconometricModels.ImpulseResponse{Float64}(
+            vals, base.ci_lower, base.ci_upper, H,
+            base.variables, base.shocks, base.ci_type,
+            reshape(vals, 1, size(vals)...) .+ scale .* dev, base._conf_level)
+        est_t = estimate_dsge(spec, Y, [:ρ]; method=:irf_matching,
+                              target_irfs=mk(0.5), irf_horizon=H, weighting=:efficient)
+        est_w = estimate_dsge(spec, Y, [:ρ]; method=:irf_matching,
+                              target_irfs=mk(2.0), irf_horizon=H, weighting=:efficient)
+        # Identical point IRFs ⇒ identical θ̂ and G; only Ω differs.
+        @test est_t.theta[1] ≈ est_w.theta[1] atol=1e-6
+        se_t = stderror(est_t)[1]; se_w = stderror(est_w)[1]
+        @test se_w > se_t
+        @test se_w/se_t ≈ 4.0 rtol=0.05   # Ω scales by (2/0.5)²=16 ⇒ SE by 4
+    end
+end
+
+@testset "IRF matching: J is Ω-weighted χ² with correct dof (T039)" begin
+    _suppress_warnings() do
+        rng = Random.MersenneTwister(4039)
+        T_obs = 400; y = zeros(T_obs)
+        for t in 2:T_obs; y[t] = 0.8*y[t-1] + randn(rng); end
+        Y = reshape(y, :, 1)
+        spec = @dsge begin
+            parameters: ρ = 0.5
+            endogenous: y
+            exogenous: ε
+            y[t] = ρ * y[t-1] + ε[t]
+        end
+        H = 10; Random.seed!(11)
+        est = estimate_dsge(spec, Y, [:ρ]; method=:irf_matching,
+                            irf_horizon=H, weighting=:efficient, n_boot=300)
+        dof = H - 1
+        @test isfinite(est.J_stat)
+        @test est.J_stat >= 0
+        @test 0.0 <= est.J_pvalue <= 1.0
+        @test est.J_stat < 5*dof   # χ²(9)-scaled J is O(dof); P(χ²(9)>45)≈9e-7
+    end
+end
+
 @testset "DSGEEstimation show and report" begin
     rng = Random.MersenneTwister(42)
     y_true = zeros(200)

--- a/test/dsge/test_ha_dsge.jl
+++ b/test/dsge/test_ha_dsge.jl
@@ -952,6 +952,32 @@ end
         ps = posterior_summary(result)
         @test haskey(ps, :alpha)
         @test isfinite(ps[:alpha][:mean])
+
+        # #136: theta0 as a Dict (order-independent) is accepted through the HA method;
+        # a wrong-length positional vector errors informatively before any solve.
+        result_dict = estimate_dsge_bayes(
+            spec, reshape(data_K, T_data, 1), Dict(:alpha => 0.36);
+            priors=priors, observables=[:K], n_draws=10, burnin=2,
+            ha_method=:ssj, ha_kwargs=(T_horizon=30, n_reduced=10),
+            proposal_scale=0.001, adapt_interval=50, rng=Random.MersenneTwister(7))
+        @test result_dict isa BayesianDSGE{Float64}
+        @test_throws ArgumentError estimate_dsge_bayes(
+            spec, reshape(data_K, T_data, 1), [0.36, 0.9];   # length 2, but 1 prior
+            priors=priors, observables=[:K], n_draws=10,
+            ha_method=:ssj, ha_kwargs=(T_horizon=30, n_reduced=10))
+
+        # #142: n×T data (1×T_data) resolves identically to T×n (same internal matrix →
+        # identical draws under the same rng); a shape matching neither dim to n_obs errors.
+        result_nt = estimate_dsge_bayes(
+            spec, reshape(data_K, 1, T_data), Dict(:alpha => 0.36);
+            priors=priors, observables=[:K], n_draws=10, burnin=2,
+            ha_method=:ssj, ha_kwargs=(T_horizon=30, n_reduced=10),
+            proposal_scale=0.001, adapt_interval=50, rng=Random.MersenneTwister(7))
+        @test result_nt.theta_draws ≈ result_dict.theta_draws
+        @test_throws ArgumentError estimate_dsge_bayes(
+            spec, randn(3, T_data), [0.36];                  # neither dim == n_obs (1)
+            priors=priors, observables=[:K], n_draws=10,
+            ha_method=:ssj, ha_kwargs=(T_horizon=30, n_reduced=10))
     end
 end
 

--- a/test/dsge/test_ha_dsge.jl
+++ b/test/dsge/test_ha_dsge.jl
@@ -911,13 +911,18 @@ end
         @test length(d) == 1
         @test size(H) == (1, 1)
         @test d[1] ≈ K_ss atol=1.0  # steady state K
-        @test H[1, 1] > 0  # positive measurement error
+        @test H[1, 1] == 0  # zero default measurement error (T042)
+        @test all(iszero, H)
 
         # Custom measurement error
         Z2, d2, H2 = MacroEconometricModels._build_ha_observation_equation(
             sol, [:K], [0.5]
         )
         @test H2[1, 1] ≈ 0.25  # 0.5^2
+
+        # Stochastic singularity: 2 observables > 1 aggregate reduced shock, no ME (T042).
+        @test_throws MacroEconometricModels.StochasticSingularityError MacroEconometricModels._build_ha_observation_equation(
+            sol, [:K, :Y], nothing)
     end
 
     @testset "estimate_dsge_bayes dispatch" begin

--- a/test/dsge/test_ha_dsge.jl
+++ b/test/dsge/test_ha_dsge.jl
@@ -944,6 +944,7 @@ end
         )
 
         @test result isa BayesianDSGE{Float64}
+        @test result.solved_at === :posterior_mean  # normal path (#149/T050)
         @test size(result.theta_draws, 2) == 1  # one parameter
         @test size(result.theta_draws, 1) == 15  # n_draws - burnin = 20 - 5
         @test length(result.log_posterior) == 15
@@ -983,6 +984,48 @@ end
             spec, randn(3, T_data), [0.36];                  # neither dim == n_obs (1)
             priors=priors, observables=[:K], n_draws=10,
             ha_method=:ssj, ha_kwargs=(T_horizon=30, n_reduced=10))
+    end
+
+    @testset "T049: default T_horizon >= 300 (truncation)" begin
+        # (A) Pin the signature default cheaply (no horizon-300 solve — those cost minutes):
+        #     the signature's ha_kwargs default uses this const.
+        @test MacroEconometricModels._HA_DEFAULT_T_HORIZON >= 300
+
+        # (B) Truncation is non-negligible: the likelihood depends on the horizon (compared
+        #     at cheap horizons; KS ρ_z=0.95 ⇒ 0.95^30≈0.21 vs 0.95^60≈0.046 tail alive).
+        ll30 = MacroEconometricModels._build_ha_likelihood_fn(
+            spec, [:alpha], reshape(data_K, 1, :), [:K], nothing, :ssj,
+            (T_horizon=30, n_reduced=15))([0.36])
+        ll60 = MacroEconometricModels._build_ha_likelihood_fn(
+            spec, [:alpha], reshape(data_K, 1, :), [:K], nothing, :ssj,
+            (T_horizon=60, n_reduced=15))([0.36])
+        @test isfinite(ll30) && isfinite(ll60)
+        @test abs(ll30 - ll60) > 1e-6
+    end
+
+    @testset "posterior-mean solution built at the mean, marked (#149/T050)" begin
+        # KS always yields a determinate, finite reduced solution for ANY θ (even NaN/Inf),
+        # so the mean-solve-fails → highest-posterior-draw branch — which mirrors the
+        # unit-tested aggregate [T044]/#143 path — is not reachable with this fast example.
+        # We verify the reachable guarantees of the fix: (a) the container is built at the
+        # POSTERIOR MEAN θ and marked, NOT silently at the original pre-estimation spec (the
+        # removed E-25 bug); (b) when no candidate yields a supported HADSGESolution the
+        # helper errors LOUDLY rather than silently substituting.
+        post_draws = reshape([0.4, 0.5, 0.6], 3, 1)   # mean = 0.5 (≠ spec's alpha=0.36)
+        post_lp    = [-3.0, -1.0, -2.0]
+        linear_sol, ss_result, solved_at, theta_used =
+            MacroEconometricModels._build_ha_result_solution(
+                spec, [:alpha], post_draws, post_lp, [:K], nothing,
+                :ssj, (T_horizon=30, n_reduced=10))
+        @test solved_at === :posterior_mean
+        @test theta_used ≈ [0.5]                    # built at the mean, not spec's 0.36
+        @test all(isfinite, linear_sol.G1)
+
+        # No candidate solves (unsupported method ⇒ no HADSGESolution) ⇒ loud error, never a
+        # silent original-spec substitution.
+        @test_throws ErrorException MacroEconometricModels._build_ha_result_solution(
+            spec, [:alpha], reshape([0.36], 1, 1), [0.0], [:K], nothing,
+            :badmethod, NamedTuple())
     end
 end
 


### PR DESCRIPTION
## Stage 4 — Bayesian DSGE validity (v0.6.2), issues #128–#150

Completes the "Bayesian DSGE validity" stage of the remediation backlog. All 23 issues implemented TDD-style, one commit per issue (grouped only where issues cross-reference), each gated on the relevant test file(s).

**Local verification (all green):** test_bayesian_dsge 1007/1007 · test_dsge 1386/1386 · test_dsge_hd 68/68 · test_ha_dsge 3355/3355 · dsge_ha.md verify_examples 1/1.

### Highlights
- **Samplers:** RWMH proposal adaptation confined to burn-in + windowed acceptance signal (#137); SMC/SMC² tempering `max_stages` + `min_dphi` guards (#145); threaded SMC² init loops with chunked workspaces (#146/#147); prior-draw exhaustion now errors instead of silently substituting a midpoint (#150).
- **Likelihood / filter:** eigenvalue-based diffuse Kalman init for unit roots, no more silent `P0=10I`, non-stability errors propagate (#139); narrow exception taxonomy (`DSGESolveError`/`_benign_solve_error`) + failure counting surfaced on the result (#140); default measurement error → zero with a stochastic-singularity check and `:auto` per-observable scaling (#141).
- **Inference / results:** valid IRF-matching minimum-distance inference — CEE sandwich, bootstrap Ω, efficient-weighting χ² J (#138); posterior-mean solve failure falls back to the highest-posterior draw, marked via a new `solved_at` field (#143), with the HA path made honest (#149); HA estimation default `T_horizon` 50→300 (Auclert et al. 2021) (#148).

### Deviations from the issue specs (issue-suggested values were wrong when tested)
- #145: `min_dphi` default is **1e-10**, not the issue's `1e-6`, which false-positived on informative likelihoods.
- #148: default pinned via a cheap const + truncation-impact demo at cheap horizons (a real horizon-300 solve costs minutes).
- #149: KS yields a determinate finite reduced solution for any θ, so the mean-fails→hpd branch mirrors the unit-tested aggregate #143 path.

Note: the Documentation `build` job is red-by-design (Stage 12 backstop); the test jobs are the gate.
