### PR TITLE
Port stranded v0.7.0 DSGE-Bayesian features onto dev (#332–#338)

### DIFF
--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -712,6 +712,9 @@ marginal_likelihood
 bayes_factor
 prior_posterior_table
 posterior_predictive
+mcmc_diagnostics
+MCMCDiagnostics
+trace
 ```
 
 ### Occasionally Binding Constraints

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -722,6 +722,10 @@ learning_rate_check
 LearningRateCheck
 prior_posterior_overlap
 PriorPosteriorOverlap
+prior_predictive
+PriorPredictiveResult
+posterior_predictive_check
+PosteriorPredictiveCheck
 ```
 
 ### Occasionally Binding Constraints

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -716,6 +716,12 @@ posterior_predictive
 mcmc_diagnostics
 MCMCDiagnostics
 trace
+identification_diagnostics
+IdentificationDiagnostics
+learning_rate_check
+LearningRateCheck
+prior_posterior_overlap
+PriorPosteriorOverlap
 ```
 
 ### Occasionally Binding Constraints

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -709,6 +709,7 @@ posterior_mode
 PosteriorMode
 posterior_summary
 marginal_likelihood
+bridge_sampling_ml
 bayes_factor
 prior_posterior_table
 posterior_predictive

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -727,6 +727,8 @@ prior_predictive
 PriorPredictiveResult
 posterior_predictive_check
 PosteriorPredictiveCheck
+dynare_prior
+InverseGamma1
 ```
 
 ### Occasionally Binding Constraints

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -483,6 +483,7 @@ Order   = [:function]
 to_unconstrained
 to_constrained
 transform_jacobian
+log_jacobian
 ```
 
 ---

--- a/docs/src/api_functions.md
+++ b/docs/src/api_functions.md
@@ -705,6 +705,8 @@ estimate_dsge
 
 ```@docs
 estimate_dsge_bayes
+posterior_mode
+PosteriorMode
 posterior_summary
 marginal_likelihood
 bayes_factor

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -613,6 +613,36 @@ All three emit a warning naming the offending parameters when something looks un
 !!! warning "Identification is observables-dependent"
     A parameter can be perfectly identified with one observable set and unidentified with another. Re-run `identification_diagnostics` with exactly the `observables` you pass to `estimate_dsge_bayes`, and check several `n_lags` horizons (Iskrev's recommendation).
 
+### Predictive Checks
+
+**Prior predictive analysis** (Geweke 2005) answers "what kind of data does my prior believe in?" *before* estimation: draw parameters from the prior, solve, simulate, and summarize. A prior that implies absurd volatilities or persistence should be revised before it distorts the posterior:
+
+```@example dsge_estimation
+ppr = prior_predictive(spec, Dict(:rho => Beta(5, 2));
+    n_draws=50, T_periods=100, observables=[:y])
+ppr
+```
+
+**Posterior predictive checks** (Gelman, Meng & Stern 1996) assess model adequacy *after* estimation: draw from the posterior, simulate replicated datasets of the observed length, and compare summary statistics. The posterior predictive p-value ``p_j = \Pr(T_j(y^{\mathrm{rep}}) \geq T_j(y^{\mathrm{obs}}))`` should be interior — extreme values (marked `*` in the table) flag the data feature the model cannot reproduce:
+
+```@example dsge_estimation
+ppc = posterior_predictive_check(result_smc; n_draws=25)
+ppc
+```
+
+**Keywords**:
+
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `n_draws` | `Int` | `500` / `200` | Prior / posterior draws to simulate |
+| `T_periods` | `Int` | `200` | Simulated periods per draw (prior predictive only) |
+| `observables` | `Vector{Symbol}` | all endogenous | Which variables to summarize (prior predictive) |
+| `data` | matrix | stored sample | Observed data override (posterior check) |
+| `stats` | function | mean/var/AR(1)/cross-corr | `Y::Matrix → (names, values)` or `NamedTuple` of scalars |
+| `rng` | `AbstractRNG` | `Random.default_rng()` | Random number generator |
+
+**Return values**: `PriorPredictiveResult` carries the `n_effective × n_stats` draw-level statistic matrix (`stats`), the labels (`stat_names`), and the effective draw count. `PosteriorPredictiveCheck` adds the `observed` statistic vector and `p_values`. In both, parameter draws for which the model fails to solve are **dropped and counted** — `n_effective` reports the draws actually used, and a warning fires when more than 10% are lost (a symptom of a prior straddling the determinacy boundary).
+
 ### Posterior IRFs and FEVD (Herbst & Schorfheide 2015)
 
 Bayesian DSGE estimation quantifies parameter uncertainty. `irf` and `fevd` propagate this uncertainty into impulse responses and variance decompositions by re-solving the model at posterior parameter draws and computing pointwise credible bands.

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -254,6 +254,29 @@ nothing # hide
 | `Normal(mu, sigma)` | ``(-\infty, \infty)`` | Unbounded parameters |
 | `Uniform(a, b)` | ``[a, b]`` | Weakly informative, bounded |
 
+#### Porting Dynare Priors
+
+Published priors are almost always declared in Dynare's **(mean, std)** convention. `dynare_prior` converts them into correctly parameterized `Distributions` objects — solving the moment-matching equations and, crucially, handling the inverse-gamma convention mismatch:
+
+| Dynare pdf | `dynare_prior` call | Returns |
+|---|---|---|
+| `normal_pdf(m, s)` | `dynare_prior(:normal, m, s)` | `Normal(m, s)` |
+| `gamma_pdf(m, s)` | `dynare_prior(:gamma, m, s)` | `Gamma(m²/s², s²/m)` |
+| `beta_pdf(m, s)` | `dynare_prior(:beta, m, s)` | moment-matched `Beta(α, β)` |
+| `beta_pdf(m, s, p3, p4)` | `dynare_prior(:beta, m, s; lower=p3, upper=p4)` | shifted/scaled Beta on `(p3, p4)` |
+| `inv_gamma_pdf(m, s)` | `dynare_prior(:inv_gamma, m, s)` | `InverseGamma1` **on σ** |
+| `inv_gamma2_pdf(m, s)` | `dynare_prior(:inv_gamma2, m, s)` | `InverseGamma` **on σ²** |
+| `uniform_pdf(...)` | `dynare_prior(:uniform, m, s)` or `; lower=a, upper=b` | `Uniform(a, b)` |
+
+```@example dsge_estimation
+priors_dynare = Dict{Symbol,Distribution}(
+    :rho => dynare_prior(:beta, 0.7, 0.1))
+mean(priors_dynare[:rho]), std(priors_dynare[:rho])
+```
+
+!!! danger "Dynare's inverse gamma is on σ, not σ²"
+    Dynare's `inv_gamma_pdf` is the **type-1** inverse gamma on the *standard deviation*; `Distributions.InverseGamma` is on the *variance*. Feeding Dynare's numbers straight into `Distributions.InverseGamma` — the natural-looking port — silently produces a completely different prior. `dynare_prior(:inv_gamma, m, s)` returns an [`InverseGamma1`](@ref) whose draws are σ values with exactly the requested mean and standard deviation (`σ² ~ InverseGamma(ν/2, s/2)` internally, matching Dynare's `(s, ν)` parameterization).
+
 ### Sequential Monte Carlo (Herbst & Schorfheide 2014)
 
 **SMC** draws from a sequence of tempered distributions that bridge the prior to the posterior:

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -571,6 +571,48 @@ round.(a.acf; digits=2)
 !!! note "SMC draws are not a chain"
     `mcmc_diagnostics` assumes Markov chain draws. Calling it on `:smc`/`:smc2` results (weighted particle systems) emits a warning — the SMC-native convergence measures are the ESS history (`result.ess_history`) and the tempering schedule (`result.phi_schedule`).
 
+### Identification Diagnostics
+
+Estimating a DSGE whose parameters are not identified by the chosen observables produces confident-looking but meaningless posteriors. Three diagnostics catch this failure mode — one before estimation, two after:
+
+**Iskrev (2010) rank test** (pre-estimation). The parameters are locally identified from the data iff the Jacobian ``J(\theta) = \partial m(\theta) / \partial \theta'`` of the model-implied data moments has full column rank. The moment vector ``m(\theta)`` stacks the observable steady-state means, the lower triangle of the contemporaneous covariance, and the autocovariance matrices at lags ``1..L`` computed from the first-order state-space solution via the Lyapunov equation. Rank deficiency names the unidentified directions through the null space of ``J``:
+
+```@example dsge_estimation
+# a and b enter the model only as the product a·b — not separately identified
+spec_bad = @dsge begin
+    parameters: a = 0.5, b = 0.9, sigma = 0.5
+    endogenous: y
+    exogenous: e
+    y[t] = a * b * y[t-1] + sigma * e[t]
+    steady_state = [0.0]
+end
+spec_bad = compute_steady_state(spec_bad)
+idd = identification_diagnostics(spec_bad, [:a, :b]; observables=[:y])
+idd
+```
+
+**Koop-Pesaran-Smith (2013) learning-rate check** (post-estimation). For an identified parameter the posterior variance shrinks at the ``1/T`` rate; `learning_rate_check` re-estimates on nested subsamples and reports the implied rate ``\alpha`` in ``\mathrm{var} \propto T^{-\alpha}`` — ``\alpha \approx 1`` is healthy, ``\alpha \approx 0`` flags a parameter whose posterior barely updates.
+
+**Prior/posterior overlap** (post-estimation). `prior_posterior_overlap` computes ``\int \min(\pi(\theta_i), p(\theta_i|Y))\,d\theta_i`` per parameter; overlap near 1 means the data never moved the prior.
+
+```julia
+lrc = learning_rate_check(fit; fractions=[0.5, 1.0], n_smc=300)  # re-estimates per subsample
+ppo = prior_posterior_overlap(fit)                                # instantaneous
+```
+
+**Keywords and return values**:
+
+| Function | Key keywords | Returns |
+|----------|--------------|---------|
+| `identification_diagnostics(spec, params; ...)` | `theta`, `observables`, `n_lags=2`, `tol_rel=√eps` | `IdentificationDiagnostics`: `rank`, `n_params`, `singular_values`, `null_space`, `identified` |
+| `learning_rate_check(result; ...)` | `fractions=[0.5,1.0]`, `n_smc=300`, `threshold=0.2` | `LearningRateCheck`: `sample_sizes`, `post_vars`, `learning_rate` (α), `flagged` |
+| `prior_posterior_overlap(result; ...)` | `n_grid=0` (auto ≈√N), `threshold=0.8` | `PriorPosteriorOverlap`: `overlap` ∈ [0,1], `flagged` |
+
+All three emit a warning naming the offending parameters when something looks unidentified; none of them throws.
+
+!!! warning "Identification is observables-dependent"
+    A parameter can be perfectly identified with one observable set and unidentified with another. Re-run `identification_diagnostics` with exactly the `observables` you pass to `estimate_dsge_bayes`, and check several `n_lags` horizons (Iskrev's recommendation).
+
 ### Posterior IRFs and FEVD (Herbst & Schorfheide 2015)
 
 Bayesian DSGE estimation quantifies parameter uncertainty. `irf` and `fevd` propagate this uncertainty into impulse responses and variance decompositions by re-solving the model at posterior parameter draws and computing pointwise credible bands.

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -480,6 +480,30 @@ ml = marginal_likelihood(result_smc)
 log_bf = bayes_factor(result1, result2)
 ```
 
+For RWMH output, `bridge_sampling_ml` provides a marginal-likelihood estimate that is far more stable than harmonic-mean-style estimators (whose importance weights can have infinite variance). It fits a proposal density to the posterior draws in the prior-transformed unconstrained space and iterates the Meng & Wong (1996) optimal-bridge recursion to convergence (Gronau et al. 2017):
+
+```@example dsge_estimation
+bml = bridge_sampling_ml(result_mode_mh)
+```
+
+**Keywords** (`bridge_sampling_ml`):
+
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `proposal` | `Symbol` | `:normal` | Proposal family fitted to the draws: `:normal` or `:t` |
+| `df` | `Real` | `5` | Degrees of freedom for the `:t` proposal |
+| `n_proposal` | `Int` | `0` | Number of proposal draws (`0` → same as the bridge half) |
+| `max_iter` | `Int` | `1000` | Maximum bridge-recursion iterations |
+| `tol` | `Real` | `1e-10` | Relative convergence tolerance on the bridge ratio |
+| `rng` | `AbstractRNG` | `Random.default_rng()` | RNG for proposal draws |
+
+**Returns**: the scalar log marginal likelihood estimate, on the same additive-constant convention as the SMC tempering-path estimate and the Laplace approximation from `posterior_mode` — the three are directly comparable via `bayes_factor`. Failure cases (chain too short, proposal too diffuse, recursion non-convergence) return `NaN` with a warning, never a silently wrong number.
+
+!!! tip "Which marginal-likelihood estimator?"
+    - **SMC** (`method=:smc`): the tempering-path estimate is a by-product — use it.
+    - **RWMH chains**: prefer **bridge sampling** over harmonic-mean estimators; it is consistent with much lighter tail conditions.
+    - **Quick model comparison at the mode**: the Laplace approximation from `posterior_mode` is instantaneous and accurate when the posterior is approximately Gaussian.
+
 ```@example dsge_estimation
 # Prior vs posterior comparison table
 tbl = prior_posterior_table(result_smc)

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -494,6 +494,59 @@ size(Y_pred)
 
 `posterior_summary` returns a `Dict{Symbol, Dict{Symbol, T}}` with keys `:mean`, `:median`, `:std`, `:ci_lower` (2.5th percentile), and `:ci_upper` (97.5th percentile) for each parameter. `prior_posterior_table` returns a vector of named tuples suitable for tabular display, comparing prior and posterior moments side by side. `posterior_predictive` draws `n_sim` parameter vectors from the posterior, solves the model at each, and simulates forward, returning an `n_sim x T_periods x n_vars` array of simulated paths.
 
+For RWMH chains, `posterior_summary` additionally annotates each parameter with its bulk effective sample size (`:ess_bulk`) and a `:low_ess` flag, and **warns** when any parameter's ESS falls below `min_ess` (default 400, per Vehtari et al. 2021) rather than silently presenting unreliable credible intervals. `prior_posterior_table` carries the same flag in a `low_ess` column.
+
+### Convergence Diagnostics
+
+Credible intervals from an MCMC chain are only as good as the chain's mixing. `mcmc_diagnostics` computes the modern standard set of per-parameter convergence diagnostics on the retained (post-burn-in) draws:
+
+- **Rank-normalized split-``\hat{R}``** (Vehtari et al. 2021): the chain is split in half, pooled draws are rank-normalized (rank → z-score via the inverse normal CDF), and ``\hat{R} = \sqrt{\widehat{\mathrm{var}}^+ / W}`` is computed from the between/within half-chain variances. The reported value is the maximum of the bulk statistic and the *folded* statistic on ``|\theta - \mathrm{median}|``, which catches scale (not just location) non-convergence. Values ``\lesssim 1.01`` indicate convergence.
+- **Bulk / tail ESS**: effective sample size from the integrated autocorrelation time ``\mathrm{ESS} = S / (1 + 2\sum_k \hat\rho_k)`` with Geyer's initial-monotone-sequence truncation. Bulk-ESS is computed on rank-normalized draws; tail-ESS is the minimum ESS of the 5% and 95% quantile indicators. Vehtari et al. recommend ESS ``\geq 400`` before trusting reported intervals.
+- **Geweke (1992) z**: spectral test comparing the mean of the first 10% against the last 50% of the chain, with numerical-standard-error variance estimates; under convergence ``z \sim N(0,1)``.
+
+```@example dsge_estimation
+diag = mcmc_diagnostics(result_mode_mh)
+diag
+```
+
+`trace` and `acf` expose the raw per-parameter draw sequence and its autocorrelation function for plotting:
+
+```@example dsge_estimation
+tr = trace(result_mode_mh, :rho)      # retained draw sequence
+length(tr)
+```
+
+```@example dsge_estimation
+a = acf(result_mode_mh, :rho; lags=5) # ACFResult (spectral acf on the chain)
+round.(a.acf; digits=2)
+```
+
+**Keywords / accessors**:
+
+| Function | Arguments | Returns |
+|----------|-----------|---------|
+| `mcmc_diagnostics(result)` | `BayesianDSGE` | `MCMCDiagnostics` (see field table below) |
+| `trace(result, param)` | result + parameter `Symbol` | `Vector{T}` of retained draws |
+| `acf(result, param; lags, conf_level)` | result + parameter `Symbol` | `ACFResult` (see [Spectral Analysis](@ref spectral_page)) |
+| `posterior_summary(result; min_ess=400)` | ESS warning threshold | summary dict + `:ess_bulk`/`:low_ess` keys (RWMH) |
+
+**Return value** (`MCMCDiagnostics` fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `param_names` | `Vector{Symbol}` | Parameter names |
+| `rhat` | `Vector{T}` | Rank-normalized split-``\hat{R}`` (max of bulk and folded) |
+| `ess_bulk` | `Vector{T}` | Bulk effective sample size |
+| `ess_tail` | `Vector{T}` | Tail effective sample size (min of 5%/95% indicators) |
+| `geweke_z` | `Vector{T}` | Geweke z-statistic |
+| `geweke_p` | `Vector{T}` | Two-sided Geweke p-value |
+| `mean`, `sd` | `Vector{T}` | Posterior mean and standard deviation |
+| `n_draws` | `Int` | Retained draws used |
+| `method` | `Symbol` | Sampler that produced the draws |
+
+!!! note "SMC draws are not a chain"
+    `mcmc_diagnostics` assumes Markov chain draws. Calling it on `:smc`/`:smc2` results (weighted particle systems) emits a warning — the SMC-native convergence measures are the ESS history (`result.ess_history`) and the tempering schedule (`result.phi_schedule`).
+
 ### Posterior IRFs and FEVD (Herbst & Schorfheide 2015)
 
 Bayesian DSGE estimation quantifies parameter uncertainty. `irf` and `fevd` propagate this uncertainty into impulse responses and variance decompositions by re-solving the model at posterior parameter draws and computing pointwise credible bands.

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -370,6 +370,68 @@ report(result_mh)
 
 RWMH is simple to implement and diagnose but converges slowly for high-dimensional parameter spaces. For models with more than 5--10 parameters, SMC is strongly preferred.
 
+### Posterior Mode and Laplace Marginal Likelihood
+
+`posterior_mode` implements the standard Dynare-style first step of Bayesian estimation: numerically maximize the log posterior, report the mode together with a Laplace approximation of the marginal likelihood, and expose the inverse Hessian at the mode as an RWMH proposal covariance.
+
+```math
+\theta^* = \arg\max_\theta \; \big[\log \mathcal{L}(Y|\theta) + \log \pi(\theta)\big]
+```
+
+The optimizer works in a **prior-transformed unconstrained space** (log for positive supports, logit for bounded intervals, via `ParameterTransform`), so bounded parameters never collide with their boundaries; the reported mode is mapped back to the natural parameter space. The Laplace approximation of the log marginal likelihood is
+
+```math
+\log \hat{p}(Y) = \log \mathcal{L}(\theta^*) + \log \pi(\theta^*) + \frac{d}{2}\log(2\pi) - \frac{1}{2}\log\det H
+```
+
+where ``H`` is the Hessian of the negative log posterior at the mode and ``d`` the number of estimated parameters (Tierney & Kadane 1986). If ``H`` is not positive definite, `laplace_log_ml` is `NaN` (with a warning) and the inverse Hessian falls back to a diagonal matrix, so downstream proposal seeding never receives a garbage covariance.
+
+```@example dsge_estimation
+pm = posterior_mode(spec, Y_data, [0.9];
+    priors=Dict(:rho => Beta(5, 2)), observables=[:y])
+pm
+```
+
+**Keywords** (`posterior_mode`):
+
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `priors` | `Dict{Symbol, Distribution}` | required | Prior distributions keyed by parameter name |
+| `observables` | `Vector{Symbol}` | `spec.endog` | Observed endogenous variables |
+| `measurement_error` | `Vector{<:Real}` | `nothing` | Measurement error standard deviations |
+| `solver` | `Symbol` | `:gensys` | DSGE solver method |
+| `solver_kwargs` | `NamedTuple` | `()` | Additional solver keyword arguments |
+| `transform` | `Bool` | `true` | Optimize in the unconstrained (prior-transformed) space |
+| `optimizer` | `Optim` method | `Optim.LBFGS()` | Any first-order `Optim.jl` optimizer |
+| `f_reltol` | `Real` | `1e-8` | Relative objective tolerance |
+| `max_iter` | `Int` | `500` | Maximum optimizer iterations |
+
+**Return value** (`PosteriorMode` fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | `Vector{T}` | Posterior mode in the natural parameter space |
+| `inv_hessian` | `Matrix{T}` | Inverse Hessian at the mode (asymptotic posterior covariance) |
+| `hessian` | `Matrix{T}` | Hessian of the negative log posterior at the mode |
+| `log_posterior` | `T` | Log posterior at the mode |
+| `log_likelihood` | `T` | Log-likelihood at the mode |
+| `laplace_log_ml` | `T` | Laplace log marginal likelihood (`NaN` if Hessian not PD) |
+| `param_names` | `Vector{Symbol}` | Parameter names (sorted prior order) |
+| `converged` | `Bool` | Optimizer convergence flag |
+| `n_iterations` | `Int` | Optimizer iterations used |
+
+To seed RWMH from the mode, pass `proposal=:mode`: the chain starts at ``\theta^*`` with proposal covariance ``c^2 H^{-1}``, ``c = 2.38/\sqrt{d}`` (Roberts & Rosenthal 2001), which typically lands the acceptance rate in the 0.2--0.4 range without hand-tuning:
+
+```@example dsge_estimation
+result_mode_mh = estimate_dsge_bayes(spec, Y_data, [0.9];
+    priors=Dict(:rho => Beta(5, 2)),
+    method=:mh, proposal=:mode, observables=[:y],
+    n_draws=50, burnin=25)
+round(result_mode_mh.acceptance_rate; digits=2)
+```
+
+The Laplace log-ML is on the same additive-constant convention as the SMC tempering-path estimate, so the two are directly comparable via `bayes_factor` (on a small linear model they agree to within about one nat).
+
 ### Bayesian Keywords
 
 | Keyword | Type | Default | Description |
@@ -388,6 +450,8 @@ RWMH is simple to implement and diagnose but converges slowly for high-dimension
 | `solver_kwargs` | `NamedTuple` | `()` | Additional solver keyword arguments |
 | `delayed_acceptance` | `Bool` | `false` | Two-stage delayed acceptance (SMC``^2`` only) |
 | `n_screen` | `Int` | `200` | Screening PF particles (delayed acceptance only) |
+| `keep_burnin` | `Bool` | `false` | Retain the full RWMH chain including burnin (e.g. for trace plots) |
+| `proposal` | `Symbol` | `:adaptive` | RWMH proposal init: `:adaptive` or `:mode` (seed from `posterior_mode`) |
 
 !!! note "Pre-Linearized Models"
     For `DSGESpec` with `linear=true` (e.g., Smets & Wouters 2007), the Kalman filter automatically computes the observation equation offset as ``d = (I - G_1)^{-1} C_{\text{sol}}``, where ``C_{\text{sol}}`` contains the constant terms from gensys. This handles models where observation equations include trend growth, steady-state inflation, or other constant offsets that are absent from the zero steady state. No user intervention is required --- `estimate_dsge_bayes` detects and handles `linear=true` models transparently.

--- a/docs/src/dsge_estimation.md
+++ b/docs/src/dsge_estimation.md
@@ -452,6 +452,10 @@ The Laplace log-ML is on the same additive-constant convention as the SMC temper
 | `n_screen` | `Int` | `200` | Screening PF particles (delayed acceptance only) |
 | `keep_burnin` | `Bool` | `false` | Retain the full RWMH chain including burnin (e.g. for trace plots) |
 | `proposal` | `Symbol` | `:adaptive` | RWMH proposal init: `:adaptive` or `:mode` (seed from `posterior_mode`) |
+| `transform` | `Bool` | `true` | RWMH walks in the prior-transformed unconstrained space with Jacobian correction |
+
+!!! note "Sampling in the unconstrained space"
+    With `transform=true` (the default for `method=:mh`), the random walk runs on ``y = T(\theta)`` — ``\log`` for positive supports, logit for bounded intervals, inferred from each prior's support — and the acceptance ratio uses ``\log p(\theta(y)|Y) + \log|J(y)|``, the correct pushforward density (Stan reference manual). A walk on a persistence near 1 or a shock standard deviation near 0 then never wastes proposals outside the support; draws are back-transformed to ``\theta`` before storage, so results are directly comparable to `transform=false`.
 
 !!! note "Pre-Linearized Models"
     For `DSGESpec` with `linear=true` (e.g., Smets & Wouters 2007), the Kalman filter automatically computes the observation equation offset as ``d = (I - G_1)^{-1} C_{\text{sol}}``, where ``C_{\text{sol}}`` contains the constant terms from gensys. This handles models where observation equations include trend growth, steady-state inflation, or other constant offsets that are absent from the zero steady state. No user intervention is required --- `estimate_dsge_bayes` detects and handles `linear=true` models transparently.

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -765,7 +765,7 @@ export optimal_weighting_matrix, identity_weighting
 export j_test, numerical_gradient
 export estimate_lp_gmm, lp_gmm_moments
 export linear_gmm_solve, gmm_sandwich_vcov, andrews_lu_mmsc
-export ParameterTransform, to_unconstrained, to_constrained, transform_jacobian
+export ParameterTransform, to_unconstrained, to_constrained, transform_jacobian, log_jacobian
 export SMMModel, estimate_smm, autocovariance_moments
 
 # =============================================================================

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -493,6 +493,7 @@ export estimate_dsge_bayes, posterior_summary, marginal_likelihood, bayes_factor
 export prior_posterior_table, posterior_predictive
 export posterior_mode, PosteriorMode
 export mcmc_diagnostics, MCMCDiagnostics, trace
+export bridge_sampling_ml
 
 # Macro
 export @dsge

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -375,6 +375,7 @@ include("dsge/kalman_dsge.jl")
 include("dsge/particle_filter.jl")
 include("dsge/smc.jl")
 include("dsge/bayes_estimation.jl")
+include("dsge/mcmc_diagnostics.jl")
 include("dsge/smoother.jl")
 include("dsge/hd.jl")
 
@@ -491,6 +492,7 @@ export BayesianDSGE, BayesianDSGESimulation
 export estimate_dsge_bayes, posterior_summary, marginal_likelihood, bayes_factor
 export prior_posterior_table, posterior_predictive
 export posterior_mode, PosteriorMode
+export mcmc_diagnostics, MCMCDiagnostics, trace
 
 # Macro
 export @dsge

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -490,6 +490,7 @@ export DSGESpec, LinearDSGE, DSGESolution, PerturbationSolution, ProjectionSolut
 export BayesianDSGE, BayesianDSGESimulation
 export estimate_dsge_bayes, posterior_summary, marginal_likelihood, bayes_factor
 export prior_posterior_table, posterior_predictive
+export posterior_mode, PosteriorMode
 
 # Macro
 export @dsge

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -498,6 +498,8 @@ export bridge_sampling_ml
 export identification_diagnostics, IdentificationDiagnostics
 export learning_rate_check, LearningRateCheck
 export prior_posterior_overlap, PriorPosteriorOverlap
+export prior_predictive, PriorPredictiveResult
+export posterior_predictive_check, PosteriorPredictiveCheck
 
 # Macro
 export @dsge

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -376,6 +376,7 @@ include("dsge/particle_filter.jl")
 include("dsge/smc.jl")
 include("dsge/bayes_estimation.jl")
 include("dsge/mcmc_diagnostics.jl")
+include("dsge/identification.jl")
 include("dsge/smoother.jl")
 include("dsge/hd.jl")
 
@@ -494,6 +495,9 @@ export prior_posterior_table, posterior_predictive
 export posterior_mode, PosteriorMode
 export mcmc_diagnostics, MCMCDiagnostics, trace
 export bridge_sampling_ml
+export identification_diagnostics, IdentificationDiagnostics
+export learning_rate_check, LearningRateCheck
+export prior_posterior_overlap, PriorPosteriorOverlap
 
 # Macro
 export @dsge

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -371,6 +371,7 @@ include("dsge/estimation.jl")
 
 # DSGE Bayesian estimation (after estimation.jl, needs DSGESpec, solve, ParameterTransform)
 include("dsge/bayes_types.jl")
+include("dsge/priors.jl")
 include("dsge/kalman_dsge.jl")
 include("dsge/particle_filter.jl")
 include("dsge/smc.jl")
@@ -500,6 +501,7 @@ export learning_rate_check, LearningRateCheck
 export prior_posterior_overlap, PriorPosteriorOverlap
 export prior_predictive, PriorPredictiveResult
 export posterior_predictive_check, PosteriorPredictiveCheck
+export dynare_prior, InverseGamma1
 
 # Macro
 export @dsge

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -961,6 +961,351 @@ function posterior_predictive(result::BayesianDSGE{T}, n_sim::Int;
 end
 
 # =============================================================================
+# Prior predictive & posterior predictive checks (Gelman, Meng & Stern 1996)
+# =============================================================================
+
+"""
+    PriorPredictiveResult{T}
+
+Prior predictive distribution of summary statistics.
+
+Fields:
+- `stat_names::Vector{String}` — statistic labels
+- `stats::Matrix{T}` — `n_effective × n_stats` draw-level statistics
+- `n_draws::Int` — requested prior draws
+- `n_effective::Int` — draws that solved and simulated successfully
+- `T_periods::Int` — simulated sample length per draw
+"""
+struct PriorPredictiveResult{T<:AbstractFloat}
+    stat_names::Vector{String}
+    stats::Matrix{T}
+    n_draws::Int
+    n_effective::Int
+    T_periods::Int
+end
+
+"""
+    PosteriorPredictiveCheck{T}
+
+Posterior predictive check result.
+
+Fields:
+- `stat_names::Vector{String}` — statistic labels
+- `observed::Vector{T}` — statistics computed on the observed data
+- `replicated::Matrix{T}` — `n_effective × n_stats` statistics on replicated datasets
+- `p_values::Vector{T}` — posterior predictive p-values `P(T(y_rep) ≥ T(y_obs))`
+- `n_draws::Int` — requested posterior draws
+- `n_effective::Int` — draws that solved and simulated successfully
+"""
+struct PosteriorPredictiveCheck{T<:AbstractFloat}
+    stat_names::Vector{String}
+    observed::Vector{T}
+    replicated::Matrix{T}
+    p_values::Vector{T}
+    n_draws::Int
+    n_effective::Int
+end
+
+"""
+    _make_default_stats(observables) → Function
+
+Default predictive summary statistics: mean, variance, and first-order
+autocorrelation of each observable, plus pairwise cross-correlations.
+"""
+function _make_default_stats(observables::Vector{Symbol})
+    return function (Y::AbstractMatrix)
+        names = String[]
+        vals = Float64[]
+        n = size(Y, 2)
+        for (j, o) in enumerate(observables)
+            yj = @view Y[:, j]
+            push!(names, "mean_$o");
+            push!(vals, mean(yj))
+            push!(names, "var_$o")
+            push!(vals, var(yj))
+            v = var(yj)
+            r1 = v > 0 ? cor(@view(Y[2:end, j]), @view(Y[1:end-1, j])) : 0.0
+            push!(names, "ar1_$o")
+            push!(vals, r1)
+        end
+        for i in 1:n, j in (i+1):n
+            push!(names, "corr_$(observables[i])_$(observables[j])")
+            push!(vals, cor(@view(Y[:, i]), @view(Y[:, j])))
+        end
+        return (names, vals)
+    end
+end
+
+"""
+    _stat_pairs(out) → (names::Vector{String}, values::Vector{Float64})
+
+Normalize a stats-function return value: accepts a `(names, values)` tuple or a
+`NamedTuple` of scalars.
+"""
+_stat_pairs(out::Tuple{<:AbstractVector,<:AbstractVector}) =
+    (String.(out[1]), Float64.(out[2]))
+_stat_pairs(out::NamedTuple) = (String.(collect(keys(out))), Float64.(collect(values(out))))
+
+"""
+    _predictive_stats_loop(spec, thetas, param_names, observables, T_periods,
+                           stats_fn, solver, solver_kwargs, rng)
+        → (stat_names, stats_matrix, n_effective)
+
+Shared loop for predictive simulation: for each parameter draw (row of
+`thetas`), solve the model, simulate `T_periods`, restrict to the observables,
+and compute the summary statistics. Failed solves/simulations are **dropped and
+counted**, never zero-filled.
+"""
+function _predictive_stats_loop(spec::DSGESpec{T}, thetas::AbstractMatrix{T},
+                                param_names::Vector{Symbol},
+                                observables::Vector{Symbol}, T_periods::Int,
+                                stats_fn, solver::Symbol,
+                                solver_kwargs::NamedTuple,
+                                rng::AbstractRNG) where {T<:AbstractFloat}
+    var_syms = spec.augmented ? spec.original_endog : spec.endog
+    obs_idx = [findfirst(==(o), var_syms) for o in observables]
+    any(isnothing, obs_idx) &&
+        throw(ArgumentError("observables must be endogenous variables of the spec"))
+    obs_idx = Vector{Int}(obs_idx)
+
+    n = size(thetas, 1)
+    stat_names = String[]
+    rows = Vector{Vector{Float64}}()
+    for s in 1:n
+        theta = Vector{T}(thetas[s, :])
+        try
+            new_pv = copy(spec.param_values)
+            for (i, pn) in enumerate(param_names)
+                new_pv[pn] = theta[i]
+            end
+            new_spec = _respec(spec, new_pv)
+            new_spec = compute_steady_state(new_spec)
+            sol = solve(new_spec; method=solver, solver_kwargs...)
+            if sol isa DSGESolution && !is_determined(sol)
+                continue
+            end
+            sim = simulate(sol, T_periods; rng=rng)      # T_periods × n_vars
+            Y = sim[:, obs_idx]
+            all(isfinite, Y) || continue
+            names, vals = _stat_pairs(stats_fn(Y))
+            if isempty(stat_names)
+                append!(stat_names, names)
+            end
+            length(vals) == length(stat_names) || continue
+            push!(rows, vals)
+        catch
+            continue
+        end
+    end
+
+    n_eff = length(rows)
+    stats_mat = n_eff == 0 ? zeros(T, 0, length(stat_names)) :
+                Matrix{T}(reduce(vcat, (permutedims(r) for r in rows)))
+    return stat_names, stats_mat, n_eff
+end
+
+"""
+    prior_predictive(spec, priors; n_draws=500, T_periods=200,
+                     observables=Symbol[], stats=nothing, solver=:gensys,
+                     solver_kwargs=NamedTuple(), rng=Random.default_rng())
+        → PriorPredictiveResult
+
+Prior predictive analysis (Geweke 2005): draw parameters from the prior, solve
+the model, simulate `T_periods` of observables, and record summary statistics
+per draw — the implied *prior predictive distribution* of the statistics. Use
+this to check whether a prior implies economically absurd data **before**
+estimating.
+
+Draws where the model fails to solve are dropped and counted (`n_effective`);
+a warning reports the skipped fraction when it exceeds 10%.
+
+# Keywords
+- `n_draws::Int=500` — prior draws
+- `T_periods::Int=200` — simulated periods per draw
+- `observables::Vector{Symbol}=Symbol[]` — observables (default: all endogenous)
+- `stats=nothing` — statistic function `Y::Matrix → (names, values)` or
+  `NamedTuple`; default: mean/variance/AR(1) per observable + cross-correlations
+- `solver`, `solver_kwargs`, `rng` — as in [`estimate_dsge_bayes`](@ref)
+"""
+function prior_predictive(spec::DSGESpec{T},
+                          priors::Dict{Symbol,<:Distribution};
+                          n_draws::Int=500,
+                          T_periods::Int=200,
+                          observables::Vector{Symbol}=Symbol[],
+                          stats=nothing,
+                          solver::Symbol=:gensys,
+                          solver_kwargs::NamedTuple=NamedTuple(),
+                          rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
+    prior = _build_bayes_prior(priors)
+    param_names = prior.param_names
+    d = length(param_names)
+    if isempty(observables)
+        observables = spec.augmented ? copy(spec.original_endog) : copy(spec.endog)
+    end
+    stats_fn = stats === nothing ? _make_default_stats(observables) : stats
+
+    thetas = zeros(T, n_draws, d)
+    for s in 1:n_draws, i in 1:d
+        for attempt in 1:100
+            draw = T(rand(rng, prior.distributions[i]))
+            if prior.lower[i] <= draw <= prior.upper[i]
+                thetas[s, i] = draw
+                break
+            end
+            if attempt == 100
+                lo = isfinite(prior.lower[i]) ? prior.lower[i] : T(0)
+                hi = isfinite(prior.upper[i]) ? prior.upper[i] : T(1)
+                thetas[s, i] = (lo + hi) / 2
+            end
+        end
+    end
+
+    stat_names, stats_mat, n_eff = _predictive_stats_loop(
+        spec, thetas, param_names, observables, T_periods, stats_fn,
+        solver, solver_kwargs, rng)
+
+    skipped = n_draws - n_eff
+    if skipped > n_draws ÷ 10
+        @warn "prior_predictive: $skipped of $n_draws prior draws failed to solve " *
+              "(indeterminate/explosive) and were dropped — the prior puts substantial " *
+              "mass outside the determinacy region"
+    end
+    n_eff == 0 && @warn "prior_predictive: no prior draw produced a valid simulation"
+
+    return PriorPredictiveResult{T}(stat_names, stats_mat, n_draws, n_eff, T_periods)
+end
+
+"""
+    posterior_predictive_check(result::BayesianDSGE; data=nothing, n_draws=200,
+                               stats=nothing, rng=Random.default_rng())
+        → PosteriorPredictiveCheck
+
+Posterior predictive checks (Gelman, Meng & Stern 1996): draw parameter vectors
+from the posterior, simulate replicated datasets of the observed sample length,
+compute summary statistics on each replication and on the observed data, and
+report the **posterior predictive p-value** per statistic,
+
+```math
+p_j = \\Pr\\big(T_j(y^{\\mathrm{rep}}) \\geq T_j(y^{\\mathrm{obs}})\\big).
+```
+
+Interior p-values (say 0.05–0.95) indicate the model reproduces that feature of
+the data; extreme p-values flag misspecification along that dimension. Failed
+draws are dropped and counted (`n_effective`), never zero-filled.
+
+# Keywords
+- `data=nothing` — observed data; default: the sample stored on the result
+- `n_draws::Int=200` — posterior draws to replicate
+- `stats=nothing` — statistic function (same contract as [`prior_predictive`](@ref))
+- `rng::AbstractRNG` — random number generator
+"""
+function posterior_predictive_check(result::BayesianDSGE{T};
+                                    data::Union{Nothing,AbstractMatrix}=nothing,
+                                    n_draws::Int=200,
+                                    stats=nothing,
+                                    rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
+    observables = isempty(result.observables) ?
+        (result.spec.augmented ? copy(result.spec.original_endog) : copy(result.spec.endog)) :
+        result.observables
+    if data === nothing
+        isempty(result.data) &&
+            throw(ArgumentError("result carries no stored data; pass data=... explicitly"))
+        data = result.data
+    end
+    # Observed data → T_obs × n_obs orientation for the stats function
+    data_no = _orient_bayes_data(data, length(observables), T)
+    Y_obs = Matrix{T}(data_no')
+    T_obs = size(Y_obs, 1)
+
+    stats_fn = stats === nothing ? _make_default_stats(observables) : stats
+    obs_names, obs_vals = _stat_pairs(stats_fn(Y_obs))
+
+    n_total = size(result.theta_draws, 1)
+    n_use = min(n_draws, n_total)
+    idx = n_use == n_total ? collect(1:n_total) : randperm(rng, n_total)[1:n_use]
+    thetas = result.theta_draws[idx, :]
+
+    stat_names, rep_mat, n_eff = _predictive_stats_loop(
+        result.spec, thetas, result.param_names, observables, T_obs, stats_fn,
+        result.solver, result.solver_kwargs, rng)
+
+    skipped = n_use - n_eff
+    skipped > n_use ÷ 10 &&
+        @warn "posterior_predictive_check: $skipped of $n_use posterior draws failed " *
+              "to solve and were dropped"
+    n_eff == 0 &&
+        throw(ArgumentError("no posterior draw produced a valid replication"))
+
+    n_stats = length(obs_names)
+    pvals = zeros(T, n_stats)
+    for j in 1:n_stats
+        pvals[j] = mean(rep_mat[:, j] .>= obs_vals[j])
+    end
+
+    return PosteriorPredictiveCheck{T}(obs_names, Vector{T}(obs_vals), rep_mat,
+                                       pvals, n_use, n_eff)
+end
+
+function Base.show(io::IO, ppr::PriorPredictiveResult{T}) where {T}
+    header = Any[
+        "Prior draws"      ppr.n_draws;
+        "Effective draws"  ppr.n_effective;
+        "Periods"          ppr.T_periods;
+        "Statistics"       length(ppr.stat_names);
+    ]
+    _pretty_table(io, header;
+        title="Prior Predictive Analysis",
+        column_labels=["", ""],
+        alignment=[:l, :r])
+    ppr.n_effective == 0 && return
+    n_stats = length(ppr.stat_names)
+    data = Matrix{Any}(undef, n_stats, 6)
+    for j in 1:n_stats
+        col = ppr.stats[:, j]
+        q = quantile(col, [0.05, 0.5, 0.95])
+        data[j, 1] = ppr.stat_names[j]
+        data[j, 2] = round(mean(col); sigdigits=4)
+        data[j, 3] = round(std(col); sigdigits=4)
+        data[j, 4] = round(q[1]; sigdigits=4)
+        data[j, 5] = round(q[2]; sigdigits=4)
+        data[j, 6] = round(q[3]; sigdigits=4)
+    end
+    _pretty_table(io, data;
+        title="Prior Predictive Distribution of Statistics",
+        column_labels=["Statistic", "Mean", "Std", "5%", "50%", "95%"],
+        alignment=[:l, :r, :r, :r, :r, :r])
+end
+
+function Base.show(io::IO, ppc::PosteriorPredictiveCheck{T}) where {T}
+    header = Any[
+        "Posterior draws"  ppc.n_draws;
+        "Effective draws"  ppc.n_effective;
+        "Statistics"       length(ppc.stat_names);
+    ]
+    _pretty_table(io, header;
+        title="Posterior Predictive Check",
+        column_labels=["", ""],
+        alignment=[:l, :r])
+    n_stats = length(ppc.stat_names)
+    data = Matrix{Any}(undef, n_stats, 6)
+    for j in 1:n_stats
+        col = ppc.replicated[:, j]
+        q = quantile(col, [0.05, 0.95])
+        p = ppc.p_values[j]
+        data[j, 1] = ppc.stat_names[j]
+        data[j, 2] = round(ppc.observed[j]; sigdigits=4)
+        data[j, 3] = round(mean(col); sigdigits=4)
+        data[j, 4] = round(q[1]; sigdigits=4)
+        data[j, 5] = round(q[2]; sigdigits=4)
+        data[j, 6] = string(round(p; digits=3), (p < 0.05 || p > 0.95) ? " *" : "")
+    end
+    _pretty_table(io, data;
+        title="Observed vs Replicated (p = P(rep ≥ obs); * = extreme)",
+        column_labels=["Statistic", "Observed", "Rep. mean", "Rep. 5%", "Rep. 95%", "p-value"],
+        alignment=[:l, :r, :r, :r, :r, :r])
+end
+
+# =============================================================================
 # Bayesian DSGE IRF — posterior credible bands
 # =============================================================================
 

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -588,7 +588,7 @@ end
 # =============================================================================
 
 """
-    posterior_summary(result::BayesianDSGE{T}) → Dict{Symbol, Dict{Symbol, T}}
+    posterior_summary(result::BayesianDSGE{T}; min_ess::Real=400) → Dict{Symbol, Dict{Symbol, T}}
 
 Compute posterior summary statistics for each estimated parameter.
 
@@ -598,8 +598,16 @@ Returns a dictionary keyed by parameter name, each containing:
 - `:std` — posterior standard deviation
 - `:ci_lower` — 2.5th percentile (lower bound of 95% credible interval)
 - `:ci_upper` — 97.5th percentile (upper bound of 95% credible interval)
+
+For RWMH chains (`method == :rwmh`), each entry additionally carries
+- `:ess_bulk` — rank-normalized bulk effective sample size (Vehtari et al. 2021)
+- `:low_ess` — `1.0` when `ess_bulk < min_ess` (default 400, the Vehtari et al.
+  recommendation), else `0.0`
+
+and a warning names the offending parameters — credible intervals from a chain
+with low ESS are not reliable. Pass a smaller `min_ess` to relax the check.
 """
-function posterior_summary(result::BayesianDSGE{T}) where {T<:AbstractFloat}
+function posterior_summary(result::BayesianDSGE{T}; min_ess::Real=400) where {T<:AbstractFloat}
     n_params = length(result.param_names)
     summary = Dict{Symbol, Dict{Symbol, T}}()
 
@@ -621,6 +629,26 @@ function posterior_summary(result::BayesianDSGE{T}) where {T<:AbstractFloat}
             :ci_lower => sorted[idx_025],
             :ci_upper => sorted[idx_975]
         )
+    end
+
+    # ESS reliability check — MCMC chains only (SMC draws are weighted particle
+    # systems where autocorrelation-based ESS does not apply)
+    if result.method == :rwmh
+        low = Symbol[]
+        for i in 1:n_params
+            pn = result.param_names[i]
+            ess_i = _ess_bulk(result.theta_draws[:, i])
+            summary[pn][:ess_bulk] = ess_i
+            is_low = isfinite(ess_i) && ess_i < min_ess
+            summary[pn][:low_ess] = is_low ? one(T) : zero(T)
+            is_low && push!(low, pn)
+        end
+        if !isempty(low)
+            @warn "posterior_summary: bulk ESS below $min_ess for " *
+                  join(string.(low), ", ") *
+                  " — credible intervals may be unreliable; run a longer chain, " *
+                  "seed the proposal via proposal=:mode, or use method=:smc"
+        end
     end
 
     return summary
@@ -669,9 +697,11 @@ Each row contains:
 - `post_std` — posterior standard deviation
 - `ci_lower` — posterior 2.5th percentile
 - `ci_upper` — posterior 97.5th percentile
+- `low_ess` — `true` when the parameter's bulk ESS falls below `min_ess`
+  (RWMH chains only; always `false` for SMC results)
 """
-function prior_posterior_table(result::BayesianDSGE{T}) where {T<:AbstractFloat}
-    ps = posterior_summary(result)
+function prior_posterior_table(result::BayesianDSGE{T}; min_ess::Real=400) where {T<:AbstractFloat}
+    ps = posterior_summary(result; min_ess=min_ess)
     n_params = length(result.param_names)
 
     rows = NamedTuple[]
@@ -686,7 +716,8 @@ function prior_posterior_table(result::BayesianDSGE{T}) where {T<:AbstractFloat}
             post_mean = ps[pn][:mean],
             post_std = ps[pn][:std],
             ci_lower = ps[pn][:ci_lower],
-            ci_upper = ps[pn][:ci_upper]
+            ci_upper = ps[pn][:ci_upper],
+            low_ess = get(ps[pn], :low_ess, zero(T)) == one(T)
         )
         push!(rows, row)
     end
@@ -1011,8 +1042,9 @@ function Base.show(io::IO, result::BayesianDSGE{T}) where {T}
         column_labels=["", ""],
         alignment=[:l, :r])
 
-    # Posterior summary table
-    pnames = [string(s) for s in result.param_names]
+    # Posterior summary table — mark low-ESS parameters (RWMH only) with †
+    pnames = [string(s) * (get(ps[s], :low_ess, zero(T)) == one(T) ? " †" : "")
+              for s in result.param_names]
     means = [ps[n][:mean] for n in result.param_names]
     stds = [ps[n][:std] for n in result.param_names]
     medians = [ps[n][:median] for n in result.param_names]
@@ -1027,8 +1059,12 @@ function Base.show(io::IO, result::BayesianDSGE{T}) where {T}
         column_labels=["Parameter", "Mean", "Std", "Median", "2.5%", "97.5%"],
         alignment=[:l, :r, :r, :r, :r, :r])
 
-    # Prior vs posterior table
-    pt = prior_posterior_table(result)
+    if any(get(ps[s], :low_ess, zero(T)) == one(T) for s in result.param_names)
+        println(io, "† bulk ESS below threshold — credible intervals may be unreliable.")
+    end
+
+    # Prior vs posterior table (min_ess=0: the ESS warning already fired above)
+    pt = prior_posterior_table(result; min_ess=0)
     if !isempty(pt)
         n_rows = length(pt)
         pp_data = Matrix{Any}(undef, n_rows, 8)

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -9,6 +9,7 @@ Public API for Bayesian DSGE estimation and posterior analysis functions.
 
 Provides:
 - `estimate_dsge_bayes` — main estimation entry point (SMC, SMC², RWMH)
+- `posterior_mode` — posterior mode + Laplace marginal likelihood + RWMH proposal seed
 - `posterior_summary` — posterior mean, median, std, credible intervals
 - `marginal_likelihood` — log marginal likelihood accessor
 - `bayes_factor` — log Bayes factor between two models
@@ -62,6 +63,44 @@ function _infer_prior_bounds(d::Distribution)
     end
 end
 
+"""
+    _build_bayes_prior(priors::Dict{Symbol,<:Distribution}) → DSGEPrior
+
+Build a `DSGEPrior` from a priors dict, auto-inferring parameter bounds from
+each distribution's support via `_infer_prior_bounds`.
+"""
+function _build_bayes_prior(priors::Dict{Symbol,<:Distribution})
+    lower_dict = Dict{Symbol,Float64}()
+    upper_dict = Dict{Symbol,Float64}()
+    for (pn, d) in priors
+        lo, hi = _infer_prior_bounds(d)
+        lower_dict[pn] = lo
+        upper_dict[pn] = hi
+    end
+    return DSGEPrior(priors; lower=lower_dict, upper=upper_dict)
+end
+
+"""
+    _orient_bayes_data(data, n_obs, ::Type{T}) → Matrix{T}
+
+Convert `data` to an `n_obs × T_obs` matrix (each column one time period), the
+orientation the Kalman/particle filters expect. Transposes when the column
+count matches `n_obs`, or best-guesses (more rows than columns → transpose)
+when neither dimension matches.
+"""
+function _orient_bayes_data(data::AbstractMatrix, n_obs::Int, ::Type{T}) where {T<:AbstractFloat}
+    data_mat = Matrix{T}(data)
+    nrows, ncols = size(data_mat)
+    if nrows != n_obs && ncols == n_obs
+        data_mat = Matrix{T}(data_mat')
+    elseif nrows != n_obs && ncols != n_obs
+        if nrows > ncols
+            data_mat = Matrix{T}(data_mat')
+        end
+    end
+    return data_mat
+end
+
 # =============================================================================
 # Main public API
 # =============================================================================
@@ -97,6 +136,11 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
   (Christen & Fox 2005). Pre-screens proposals with a cheap bootstrap PF to avoid
   expensive CSMC evaluations on proposals that would be rejected. Exact posterior.
 - `n_screen::Int=200` — particles for screening PF (only used when `delayed_acceptance=true`)
+- `proposal::Symbol=:adaptive` — RWMH proposal initialization (`:mh` only). `:adaptive`
+  keeps the current behavior (identity proposal, adapted along the chain). `:mode` first
+  runs [`posterior_mode`](@ref) and seeds the chain at the mode with proposal covariance
+  `c²·H⁻¹` where `c = 2.38/√d` (Roberts & Rosenthal 2001 optimal scaling) and `H` is the
+  negative-log-posterior Hessian at the mode.
 - `rng::AbstractRNG=Random.default_rng()` — random number generator
 
 # Returns
@@ -126,24 +170,15 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               solver_kwargs::NamedTuple=NamedTuple(),
                               delayed_acceptance::Bool=false,
                               n_screen::Int=200,
+                              proposal::Symbol=:adaptive,
                               rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
 
-    # ── 1. Build DSGEPrior from priors dict ──────────────────────────────
-    # Auto-infer bounds from distribution support
-    lower_dict = Dict{Symbol,Float64}()
-    upper_dict = Dict{Symbol,Float64}()
-    for (pn, d) in priors
-        lo, hi = _infer_prior_bounds(d)
-        lower_dict[pn] = lo
-        upper_dict[pn] = hi
-    end
-    prior = DSGEPrior(priors; lower=lower_dict, upper=upper_dict)
+    # ── 1. Build DSGEPrior from priors dict (bounds inferred from support) ─
+    prior = _build_bayes_prior(priors)
 
     # ── 2. Sort param_names to match DSGEPrior ordering ──────────────────
     param_names = prior.param_names  # already sorted by DSGEPrior constructor
 
-    # Sort theta0 to match param_names ordering
-    prior_keys_sorted = param_names
     # theta0 is provided in the same order as the sorted prior keys
     theta0_sorted = T.(theta0)
 
@@ -154,23 +189,16 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
     n_obs = length(observables)
 
     # ── 4. Data handling: ensure n_obs × T_obs format ────────────────────
-    data_mat = Matrix{T}(data)
-    nrows, ncols = size(data_mat)
-    # The Kalman filter expects n_obs × T_obs (each column is one time period)
-    # simulate() returns T_periods × n_endog
-    # If data has more rows than columns and nrows != n_obs, transpose
-    if nrows != n_obs && ncols == n_obs
-        data_mat = Matrix{T}(data_mat')
-    elseif nrows != n_obs && ncols != n_obs
-        # Neither dimension matches n_obs; try best guess: if nrows > ncols, transpose
-        if nrows > ncols
-            data_mat = Matrix{T}(data_mat')
-        end
-    end
+    # The Kalman filter expects n_obs × T_obs (each column is one time period);
+    # simulate() returns T_periods × n_endog.
+    data_mat = _orient_bayes_data(data, n_obs, T)
 
-    # ── 5. Validate method ───────────────────────────────────────────────
+    # ── 5. Validate method / proposal ────────────────────────────────────
     if method ∉ (:smc, :smc2, :mh)
         throw(ArgumentError("method must be :smc, :smc2, or :mh, got :$method"))
+    end
+    if proposal ∉ (:adaptive, :mode)
+        throw(ArgumentError("proposal must be :adaptive or :mode, got :$proposal"))
     end
 
     # ── 6. Dispatch to sampler ───────────────────────────────────────────
@@ -198,12 +226,24 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                                             solver, solver_kwargs)
 
     else  # :mh
+        theta_init = theta0_sorted
+        init_proposal_cov = nothing
+        if proposal == :mode
+            pm = posterior_mode(spec, data_mat, theta0_sorted;
+                                priors=priors, observables=observables,
+                                measurement_error=measurement_error,
+                                solver=solver, solver_kwargs=solver_kwargs)
+            c2 = T(2.38)^2 / T(length(param_names))
+            init_proposal_cov = c2 .* pm.inv_hessian
+            theta_init = pm.mode
+        end
         draws, log_posterior, acceptance_rate = _mh_sample(
-            spec, data_mat, param_names, prior, theta0_sorted;
+            spec, data_mat, param_names, prior, theta_init;
             n_draws=n_draws, burnin=burnin,
             observables=observables,
             measurement_error=measurement_error,
-            solver=solver, solver_kwargs=solver_kwargs, rng=rng)
+            solver=solver, solver_kwargs=solver_kwargs,
+            init_proposal_cov=init_proposal_cov, rng=rng)
         # Discard burn-in so posterior summaries exclude the transient. The burnin kwarg was
         # previously a no-op for :mh (all draws stored). keep_burnin=true retains the full
         # chain (e.g. for trace plots) without affecting the default summaries (E-03 / #122).
@@ -217,6 +257,188 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                                      observables, measurement_error,
                                      solver, solver_kwargs)
     end
+end
+
+# =============================================================================
+# Posterior mode finding + Laplace marginal likelihood (Dynare-style workflow)
+# =============================================================================
+
+"""
+    posterior_mode(spec, data, θ0; priors, kwargs...) → PosteriorMode
+
+Find the posterior mode of a DSGE model by numerically maximizing
+`log p(θ|Y) ∝ log L(θ) + log π(θ)`, and compute the Laplace approximation of
+the log marginal likelihood plus the inverse Hessian at the mode (the
+asymptotic posterior covariance, usable as an RWMH proposal via
+`estimate_dsge_bayes(...; method=:mh, proposal=:mode)`).
+
+Optimization runs in a prior-transformed unconstrained space by default
+(log for positive supports, logit for bounded intervals, via
+[`ParameterTransform`](@ref)), so bounded parameters never hit their
+boundaries; the returned mode is in the natural parameter space. The
+transform only reparameterizes the optimizer — the objective is the
+natural-space log posterior, so the maximizer is the natural-space mode.
+
+The Laplace approximation is
+```math
+\\log \\hat p(Y) = \\log L(\\theta^*) + \\log \\pi(\\theta^*)
+    + \\tfrac{d}{2}\\log(2\\pi) - \\tfrac{1}{2}\\log\\det H,
+```
+where `H` is the Hessian of the negative log posterior at the mode `θ*` and
+`d` the number of estimated parameters (Tierney & Kadane 1986). If `H` is not
+finite and positive definite, `laplace_log_ml` is `NaN`, a warning is emitted,
+and `inv_hessian` falls back to a diagonal matrix.
+
+# Arguments
+- `spec::DSGESpec{T}` — model specification from `@dsge`
+- `data::AbstractMatrix` — observed data (`T_obs × n_obs` or `n_obs × T_obs`, auto-detected)
+- `θ0::AbstractVector{<:Real}` — initial guess, ordered like the sorted prior keys
+
+# Keywords
+- `priors::Dict{Symbol,<:Distribution}` — prior distributions keyed by parameter name
+- `observables::Vector{Symbol}=Symbol[]` — observed endogenous variables (default: all)
+- `measurement_error=nothing` — measurement error SDs
+- `solver::Symbol=:gensys` — DSGE solver method
+- `solver_kwargs::NamedTuple=NamedTuple()` — additional solver kwargs
+- `transform::Bool=true` — optimize in the unconstrained (prior-transformed) space
+- `optimizer=Optim.LBFGS()` — any `Optim.jl` first-order optimizer
+- `f_reltol::Real=1e-8` — relative objective tolerance (`Optim.Options` `f_reltol`)
+- `max_iter::Int=500` — maximum optimizer iterations
+
+# Returns
+[`PosteriorMode`](@ref) carrying the mode, inverse Hessian, log posterior at
+the mode, and the Laplace log marginal likelihood.
+
+# References
+- Tierney, L. & Kadane, J. B. (1986). Accurate Approximations for Posterior
+  Moments and Marginal Densities. *JASA*, 81(393), 82-86.
+- Roberts, G. O. & Rosenthal, J. S. (2001). Optimal Scaling for Various
+  Metropolis-Hastings Algorithms. *Statistical Science*, 16(4), 351-367.
+"""
+function posterior_mode(spec::DSGESpec{T}, data::AbstractMatrix,
+                        theta0::AbstractVector{<:Real};
+                        priors::Dict{Symbol,<:Distribution},
+                        observables::Vector{Symbol}=Symbol[],
+                        measurement_error=nothing,
+                        solver::Symbol=:gensys,
+                        solver_kwargs::NamedTuple=NamedTuple(),
+                        transform::Bool=true,
+                        optimizer=Optim.LBFGS(),
+                        f_reltol::Real=1e-8,
+                        max_iter::Int=500) where {T<:AbstractFloat}
+    prior = _build_bayes_prior(priors)
+    param_names = prior.param_names
+    d = length(param_names)
+    length(theta0) == d ||
+        throw(ArgumentError("theta0 has length $(length(theta0)), expected $d (one per prior)"))
+
+    if isempty(observables)
+        observables = copy(spec.endog)
+    end
+    data_mat = _orient_bayes_data(data, length(observables), T)
+
+    # Same likelihood closure the samplers use, so mode and chain see identical evaluations
+    ll_fn = _build_likelihood_fn(spec, param_names, data_mat, observables,
+                                 measurement_error, solver, solver_kwargs)
+
+    penalty = T(1e10)
+    function logpost(theta::Vector{T})
+        lp = _log_prior(theta, prior)
+        isfinite(lp) || return -penalty
+        ll = ll_fn(theta)
+        isfinite(ll) || return -penalty
+        return ll + lp
+    end
+
+    # Nudge θ0 strictly inside the prior support so the transform is finite
+    theta_start = Vector{T}(theta0)
+    for i in 1:d
+        lo, hi = prior.lower[i], prior.upper[i]
+        span = isfinite(lo) && isfinite(hi) ? hi - lo : one(T)
+        margin = T(1e-8) * span
+        if isfinite(lo) && theta_start[i] <= lo
+            theta_start[i] = lo + margin
+        end
+        if isfinite(hi) && theta_start[i] >= hi
+            theta_start[i] = hi - margin
+        end
+    end
+
+    opts = Optim.Options(f_reltol=T(f_reltol), iterations=max_iter)
+    local res, theta_star
+    if transform
+        pt = ParameterTransform(prior.lower, prior.upper)
+        phi0 = to_unconstrained(pt, theta_start)
+        obj_phi = phi -> -logpost(to_constrained(pt, phi))
+        res = Optim.optimize(obj_phi, phi0, optimizer, opts)
+        theta_star = to_constrained(pt, Optim.minimizer(res))
+    else
+        obj = theta -> -logpost(Vector{T}(theta))
+        res = Optim.optimize(obj, theta_start, optimizer, opts)
+        theta_star = Vector{T}(Optim.minimizer(res))
+    end
+
+    ll_star = ll_fn(theta_star)
+    lpost_star = logpost(theta_star)
+
+    # Hessian of the NEGATIVE log posterior at the mode, in the natural space.
+    # ForwardDiff first (fast if the likelihood path is Dual-compatible), falling
+    # back to central finite differences (the QZ-based solvers are not).
+    negpost = theta -> -logpost(Vector{T}(theta))
+    H = try
+        ForwardDiff.hessian(negpost, theta_star)
+    catch
+        _numerical_hessian(negpost, theta_star; eps_step=T(1e-4))
+    end
+    H = Matrix{T}((H + H') / 2)
+
+    Hh = Hermitian(H)
+    hessian_ok = all(isfinite, H) && isposdef(Hh)
+    local inv_H, laplace_log_ml
+    if hessian_ok
+        inv_H = Matrix{T}(robust_inv(Hh))
+        laplace_log_ml = lpost_star + T(d) / 2 * log(T(2) * T(pi)) - logdet_safe(H) / 2
+    else
+        @warn "posterior_mode: Hessian at the mode is not finite positive definite; " *
+              "Laplace log-ML set to NaN and inv_hessian falls back to a diagonal matrix"
+        diag_fallback = ones(T, d)
+        for i in 1:d
+            hii = H[i, i]
+            if isfinite(hii) && hii > 0
+                diag_fallback[i] = one(T) / hii
+            end
+        end
+        inv_H = Matrix{T}(Diagonal(diag_fallback))
+        laplace_log_ml = T(NaN)
+    end
+
+    return PosteriorMode{T}(theta_star, inv_H, H, lpost_star, ll_star,
+                            laplace_log_ml, param_names,
+                            Optim.converged(res), Optim.iterations(res))
+end
+
+function Base.show(io::IO, pm::PosteriorMode{T}) where {T}
+    d = length(pm.param_names)
+    spec_data = Any[
+        "Parameters"           d;
+        "Log posterior"        round(pm.log_posterior; digits=4);
+        "Log likelihood"       round(pm.log_likelihood; digits=4);
+        "Laplace log-ML"       round(pm.laplace_log_ml; digits=4);
+        "Converged"            pm.converged;
+        "Iterations"           pm.n_iterations;
+    ]
+    _pretty_table(io, spec_data;
+        title="DSGE Posterior Mode (Laplace)",
+        column_labels=["", ""],
+        alignment=[:l, :r])
+
+    sds = [pm.inv_hessian[i, i] > 0 ? sqrt(pm.inv_hessian[i, i]) : T(NaN) for i in 1:d]
+    mode_data = hcat([string(p) for p in pm.param_names],
+                     round.(pm.mode; digits=4), round.(sds; digits=4))
+    _pretty_table(io, mode_data;
+        title="Posterior Mode",
+        column_labels=["Parameter", "Mode", "Std (Laplace)"],
+        alignment=[:l, :r, :r])
 end
 
 # =============================================================================

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -1033,7 +1033,7 @@ function _make_default_stats(observables::Vector{Symbol})
     return function (Y::AbstractMatrix)
         names = String[]
         vals = Float64[]
-        n = size(Y, 2)
+        n = length(observables)
         for (j, o) in enumerate(observables)
             yj = @view Y[:, j]
             push!(names, "mean_$o");

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -142,6 +142,11 @@ SMC², or Random-Walk Metropolis-Hastings (RWMH).
   runs [`posterior_mode`](@ref) and seeds the chain at the mode with proposal covariance
   `c²·H⁻¹` where `c = 2.38/√d` (Roberts & Rosenthal 2001 optimal scaling) and `H` is the
   negative-log-posterior Hessian at the mode.
+- `transform::Bool=true` — RWMH walks in the prior-transformed unconstrained space
+  (`:mh` only): log for positive supports, logit for bounded intervals, with the
+  log-Jacobian added to the target so the θ-space posterior is preserved. No proposal
+  is ever wasted outside the parameter support. `transform=false` restores the
+  natural-space walk.
 - `rng::AbstractRNG=Random.default_rng()` — random number generator
 
 # Returns
@@ -172,6 +177,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               delayed_acceptance::Bool=false,
                               n_screen::Int=200,
                               proposal::Symbol=:adaptive,
+                              transform::Bool=true,
                               rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
 
     # ── 1. Build DSGEPrior from priors dict (bounds inferred from support) ─
@@ -237,6 +243,16 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
             c2 = T(2.38)^2 / T(length(param_names))
             init_proposal_cov = c2 .* pm.inv_hessian
             theta_init = pm.mode
+            if transform
+                # The walk runs in y-space: map the θ-space covariance through
+                # the inverse Jacobian at the mode, Σ_y = D⁻¹ Σ_θ D⁻¹
+                pt = ParameterTransform(prior.lower, prior.upper)
+                y_mode = to_unconstrained(pt, pm.mode)
+                D = transform_jacobian(pt, y_mode)
+                Dinv = Diagonal([D[i, i] != 0 ? 1 / D[i, i] : one(T)
+                                 for i in 1:size(D, 1)])
+                init_proposal_cov = Matrix{T}(Dinv * init_proposal_cov * Dinv)
+            end
         end
         draws, log_posterior, acceptance_rate = _mh_sample(
             spec, data_mat, param_names, prior, theta_init;
@@ -244,7 +260,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
             observables=observables,
             measurement_error=measurement_error,
             solver=solver, solver_kwargs=solver_kwargs,
-            init_proposal_cov=init_proposal_cov, rng=rng)
+            init_proposal_cov=init_proposal_cov, transform=transform, rng=rng)
         # Discard burn-in so posterior summaries exclude the transient. The burnin kwarg was
         # previously a no-op for :mh (all draws stored). keep_burnin=true retains the full
         # chain (e.g. for trace plots) without affecting the default summaries (E-03 / #122).
@@ -789,8 +805,9 @@ function bridge_sampling_ml(result::BayesianDSGE{T};
     g = proposal == :normal ? MvNormal(mu_g, Sigma_pd) :
                               MvTDist(T(df), mu_g, Sigma_pd)
 
-    # log |J(φ)| — Jacobian of the unconstrained → constrained map
-    log_jac(phiv) = sum(log(abs(transform_jacobian(pt, phiv)[k, k])) for k in 1:d)
+    # log |J(φ)| — Jacobian of the unconstrained → constrained map (shared,
+    # numerically stable implementation)
+    log_jac(phiv) = log_jacobian(pt, phiv)
 
     # ℓ₁: posterior-kernel over proposal at the bridge half (kernel values stored)
     l1 = zeros(T, n1)

--- a/src/dsge/bayes_estimation.jl
+++ b/src/dsge/bayes_estimation.jl
@@ -12,6 +12,7 @@ Provides:
 - `posterior_mode` — posterior mode + Laplace marginal likelihood + RWMH proposal seed
 - `posterior_summary` — posterior mean, median, std, credible intervals
 - `marginal_likelihood` — log marginal likelihood accessor
+- `bridge_sampling_ml` — bridge sampling log marginal likelihood (Meng & Wong 1996)
 - `bayes_factor` — log Bayes factor between two models
 - `prior_posterior_table` — prior vs posterior comparison
 - `posterior_predictive` — simulate from posterior draws
@@ -210,7 +211,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                              solver=solver, solver_kwargs=solver_kwargs, rng=rng)
         return _smc_state_to_bayesian_dsge(state, prior, param_names, spec, :smc,
                                             observables, measurement_error,
-                                            solver, solver_kwargs)
+                                            solver, solver_kwargs, data_mat)
 
     elseif method == :smc2
         state = _smc2_sample(spec, data_mat, param_names, prior, theta0_sorted;
@@ -223,7 +224,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
                               n_screen=n_screen, rng=rng)
         return _smc_state_to_bayesian_dsge(state, prior, param_names, spec, :smc2,
                                             observables, measurement_error,
-                                            solver, solver_kwargs)
+                                            solver, solver_kwargs, data_mat)
 
     else  # :mh
         theta_init = theta0_sorted
@@ -255,7 +256,7 @@ function estimate_dsge_bayes(spec::DSGESpec{T}, data::AbstractMatrix,
         return _mh_to_bayesian_dsge(draws, log_posterior, acceptance_rate,
                                      prior, param_names, spec,
                                      observables, measurement_error,
-                                     solver, solver_kwargs)
+                                     solver, solver_kwargs, data_mat)
     end
 end
 
@@ -457,7 +458,8 @@ function _smc_state_to_bayesian_dsge(state::SMCState{T}, prior::DSGEPrior{T},
                                        observables::Vector{Symbol},
                                        measurement_error,
                                        solver::Symbol,
-                                       solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+                                       solver_kwargs::NamedTuple,
+                                       data::Matrix{T}=zeros(T, 0, 0)) where {T<:AbstractFloat}
     # theta_draws: transpose from n_params × N_smc to N_smc × n_params
     theta_draws = Matrix{T}(state.theta_particles')
 
@@ -488,7 +490,8 @@ function _smc_state_to_bayesian_dsge(state::SMCState{T}, prior::DSGEPrior{T},
         theta_draws, log_posterior, param_names, prior,
         state.log_marginal_likelihood, method_sym, acceptance_rate,
         state.ess_history, state.phi_schedule,
-        spec, sol, ss
+        spec, sol, ss,
+        data, observables, measurement_error, solver, solver_kwargs
     )
 end
 
@@ -511,7 +514,8 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
                                 observables::Vector{Symbol},
                                 measurement_error,
                                 solver::Symbol,
-                                solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+                                solver_kwargs::NamedTuple,
+                                data::Matrix{T}=zeros(T, 0, 0)) where {T<:AbstractFloat}
     # Posterior mean from draws
     theta_mean = vec(mean(draws; dims=1))
 
@@ -536,7 +540,8 @@ function _mh_to_bayesian_dsge(draws::Matrix{T}, log_posterior::Vector{T},
         draws, log_posterior, param_names, prior,
         log_ml, :rwmh, acceptance_rate,
         T[], T[],  # no ESS history or phi schedule for MH
-        spec, sol, ss
+        spec, sol, ss,
+        data, observables, measurement_error, solver, solver_kwargs
     )
 end
 
@@ -681,6 +686,173 @@ Following Kass & Raftery (1995), `2 * log BF > 6` is strong evidence.
 """
 function bayes_factor(r1::BayesianDSGE, r2::BayesianDSGE)
     return r1.log_marginal_likelihood - r2.log_marginal_likelihood
+end
+
+"""
+    bridge_sampling_ml(result::BayesianDSGE; proposal=:normal, df=5,
+                       n_proposal=0, max_iter=1000, tol=1e-10,
+                       rng=Random.default_rng()) → T
+
+Bridge sampling estimate of the log marginal likelihood from stored posterior
+draws (Meng & Wong 1996), using the optimal bridge function with the iterative
+implementation of Gronau et al. (2017).
+
+The estimator works in the **prior-transformed unconstrained space** (same
+[`ParameterTransform`](@ref) as [`posterior_mode`](@ref)): the posterior draws
+are mapped through the transform, a multivariate normal (or Student-t) proposal
+`g` is fitted to the first half of the transformed draws, and the bridge
+recursion
+
+```math
+r_{t+1} = \\frac{\\tfrac{1}{N_2}\\sum_j \\ell_{2,j} / (s_1 \\ell_{2,j} + s_2 r_t)}
+               {\\tfrac{1}{N_1}\\sum_i 1 / (s_1 \\ell_{1,i} + s_2 r_t)},
+\\qquad \\ell = \\frac{p(Y|\\theta)\\,\\pi(\\theta)\\,|J(\\phi)|}{g(\\phi)}
+```
+
+is iterated to convergence on the second half (`ℓ₁`) and fresh draws from `g`
+(`ℓ₂`); `log p̂(Y) = log r^*`. All averages run in shifted log space to avoid
+overflow. Bridge sampling is markedly more stable than the modified harmonic
+mean, whose importance weights can have infinite variance.
+
+Returns `NaN` with a warning when the chain is too short, the result carries no
+estimation data, too few proposal draws yield a finite posterior kernel, or the
+recursion fails to converge — never a silently wrong number. The additive
+constant convention matches the SMC tempering-path estimate, so the two are
+comparable via [`bayes_factor`](@ref).
+
+# Keywords
+- `proposal::Symbol=:normal` — proposal family: `:normal` or `:t` (Student-t)
+- `df::Real=5` — degrees of freedom for the `:t` proposal
+- `n_proposal::Int=0` — number of proposal draws (`0` → same as bridge half)
+- `max_iter::Int=1000` — maximum bridge iterations
+- `tol::Real=1e-10` — relative convergence tolerance on `r`
+- `rng::AbstractRNG` — random number generator for proposal draws
+
+# References
+- Meng, X.-L. & Wong, W. H. (1996). Simulating Ratios of Normalizing Constants
+  via a Simple Identity. *Statistica Sinica*, 6, 831-860.
+- Gronau, Q. F. et al. (2017). A Tutorial on Bridge Sampling.
+  *Journal of Mathematical Psychology*, 81, 80-97.
+"""
+function bridge_sampling_ml(result::BayesianDSGE{T};
+                            proposal::Symbol=:normal,
+                            df::Real=5,
+                            n_proposal::Int=0,
+                            max_iter::Int=1000,
+                            tol::Real=1e-10,
+                            rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
+    proposal in (:normal, :t) ||
+        throw(ArgumentError("proposal must be :normal or :t, got :$proposal"))
+    N, d = size(result.theta_draws)
+
+    if isempty(result.data)
+        @warn "bridge_sampling_ml: result carries no estimation data " *
+              "(hand-constructed result?); returning NaN"
+        return T(NaN)
+    end
+    if N < max(20, 4 * d)
+        @warn "bridge_sampling_ml: chain too short (N=$N draws for d=$d " *
+              "parameters); returning NaN"
+        return T(NaN)
+    end
+
+    prior = result.priors
+    pt = ParameterTransform(prior.lower, prior.upper)
+
+    # Transform all draws to the unconstrained space
+    phi = zeros(T, N, d)
+    for i in 1:N
+        phi[i, :] = to_unconstrained(pt, result.theta_draws[i, :])
+    end
+    finite_rows = [all(isfinite, @view phi[i, :]) for i in 1:N]
+    if !all(finite_rows)
+        keep = findall(finite_rows)
+        length(keep) < max(20, 4 * d) &&
+            (@warn "bridge_sampling_ml: too few interior draws after transform"; return T(NaN))
+        phi = phi[keep, :]
+        N = length(keep)
+    end
+
+    # First half fits the proposal, second half enters the bridge (Gronau et al.)
+    n_fit = N ÷ 2
+    idx_bridge = (n_fit+1):N
+    n1 = length(idx_bridge)
+    n2 = n_proposal > 0 ? n_proposal : n1
+
+    mu_g = vec(mean(@view(phi[1:n_fit, :]); dims=1))
+    Sigma_g = cov(@view(phi[1:n_fit, :]))
+    Sigma_g = Matrix{T}((Sigma_g + Sigma_g') / 2)
+    L = _suppress_warnings() do
+        safe_cholesky(Sigma_g)
+    end
+    Sigma_pd = Matrix{T}(L * L')
+    g = proposal == :normal ? MvNormal(mu_g, Sigma_pd) :
+                              MvTDist(T(df), mu_g, Sigma_pd)
+
+    # log |J(φ)| — Jacobian of the unconstrained → constrained map
+    log_jac(phiv) = sum(log(abs(transform_jacobian(pt, phiv)[k, k])) for k in 1:d)
+
+    # ℓ₁: posterior-kernel over proposal at the bridge half (kernel values stored)
+    l1 = zeros(T, n1)
+    for (k, i) in enumerate(idx_bridge)
+        phiv = phi[i, :]
+        l1[k] = result.log_posterior[i] + log_jac(phiv) - T(logpdf(g, phiv))
+    end
+
+    # ℓ₂: posterior-kernel over proposal at fresh g draws — evaluated through the
+    # same likelihood closure the samplers used
+    ll_fn = _build_likelihood_fn(result.spec, result.param_names, result.data,
+                                 result.observables, result.measurement_error,
+                                 result.solver, result.solver_kwargs)
+    phi_g = rand(rng, g, n2)                       # d × n2
+    l2 = fill(T(-Inf), n2)
+    for j in 1:n2
+        phiv = Vector{T}(phi_g[:, j])
+        theta_j = to_constrained(pt, phiv)
+        lp = _log_prior(theta_j, prior)
+        isfinite(lp) || continue
+        ll = ll_fn(theta_j)
+        isfinite(ll) || continue
+        l2[j] = ll + lp + log_jac(phiv) - T(logpdf(g, phiv))
+    end
+    n2_finite = count(isfinite, l2)
+    if n2_finite < max(10, n2 ÷ 20)
+        @warn "bridge_sampling_ml: only $n2_finite of $n2 proposal draws yield a " *
+              "finite posterior kernel; proposal too diffuse — returning NaN"
+        return T(NaN)
+    end
+
+    # Bridge recursion in shifted log space
+    lstar = median(filter(isfinite, l1))
+    e1 = [isfinite(v) ? exp(v - lstar) : zero(T) for v in l1]
+    e2 = [isfinite(v) ? exp(v - lstar) : zero(T) for v in l2]
+    s1 = T(n1) / (n1 + n2)
+    s2 = T(n2) / (n1 + n2)
+
+    r = one(T)
+    converged = false
+    for _ in 1:max_iter
+        num = mean(e2 ./ (s1 .* e2 .+ s2 * r))
+        den = mean(one(T) ./ (s1 .* e1 .+ s2 * r))
+        r_new = num / den
+        if !isfinite(r_new) || r_new <= 0
+            break
+        end
+        if abs(r_new - r) <= tol * abs(r_new)
+            r = r_new
+            converged = true
+            break
+        end
+        r = r_new
+    end
+
+    if !converged || !isfinite(r) || r <= 0
+        @warn "bridge_sampling_ml: bridge recursion did not converge in " *
+              "$max_iter iterations; returning NaN"
+        return T(NaN)
+    end
+
+    return log(r) + lstar
 end
 
 """

--- a/src/dsge/bayes_types.jl
+++ b/src/dsge/bayes_types.jl
@@ -575,3 +575,38 @@ struct BayesianDSGESimulation{T<:AbstractFloat}
     quantile_levels::Vector{T}
     all_paths::Array{T,3}
 end
+
+# =============================================================================
+# PosteriorMode — posterior mode + Laplace approximation result
+# =============================================================================
+
+"""
+    PosteriorMode{T}
+
+Posterior mode result for Bayesian DSGE estimation (Dynare-style mode finding).
+
+Fields:
+- `mode::Vector{T}` — posterior mode in the natural (constrained) parameter space
+- `inv_hessian::Matrix{T}` — inverse Hessian of the negative log posterior at the
+  mode (asymptotic posterior covariance); diagonal fallback if the Hessian is not
+  positive definite
+- `hessian::Matrix{T}` — Hessian of the negative log posterior at the mode
+- `log_posterior::T` — log posterior (log-likelihood + log prior) at the mode
+- `log_likelihood::T` — log-likelihood at the mode
+- `laplace_log_ml::T` — Laplace approximation of the log marginal likelihood
+  (`NaN` if the Hessian is not positive definite)
+- `param_names::Vector{Symbol}` — parameter names (sorted, matching `DSGEPrior`)
+- `converged::Bool` — optimizer convergence flag
+- `n_iterations::Int` — optimizer iteration count
+"""
+struct PosteriorMode{T<:AbstractFloat}
+    mode::Vector{T}
+    inv_hessian::Matrix{T}
+    hessian::Matrix{T}
+    log_posterior::T
+    log_likelihood::T
+    laplace_log_ml::T
+    param_names::Vector{Symbol}
+    converged::Bool
+    n_iterations::Int
+end

--- a/src/dsge/bayes_types.jl
+++ b/src/dsge/bayes_types.jl
@@ -521,6 +521,12 @@ Fields:
 - `spec::DSGESpec{T}` — model specification
 - `solution::Union{DSGESolution{T}, PerturbationSolution{T}}` — solution at posterior mode
 - `state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}}` — state space at posterior mode
+- `data::Matrix{T}` — observed data (n_obs × T_obs) used for estimation (empty if
+  the result was built without estimation context, e.g. hand-constructed)
+- `observables::Vector{Symbol}` — observed endogenous variables
+- `measurement_error::Union{Nothing,Vector{T}}` — measurement error SDs
+- `solver::Symbol` — DSGE solver used during estimation
+- `solver_kwargs::NamedTuple` — solver keyword arguments used during estimation
 """
 struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     theta_draws::Matrix{T}
@@ -535,18 +541,29 @@ struct BayesianDSGE{T<:AbstractFloat} <: AbstractDSGEModel
     spec::DSGESpec{T}
     solution::Union{DSGESolution{T}, PerturbationSolution{T}, ProjectionSolution{T}}
     state_space::Union{DSGEStateSpace{T}, NonlinearStateSpace{T}, ProjectionStateSpace{T}}
+    data::Matrix{T}
+    observables::Vector{Symbol}
+    measurement_error::Union{Nothing,Vector{T}}
+    solver::Symbol
+    solver_kwargs::NamedTuple
 
     function BayesianDSGE{T}(theta_draws, log_posterior, param_names, priors,
                               log_marginal_likelihood, method, acceptance_rate,
                               ess_history, phi_schedule, spec, solution,
-                              state_space) where {T<:AbstractFloat}
+                              state_space,
+                              data=zeros(T, 0, 0), observables=Symbol[],
+                              measurement_error=nothing, solver=:gensys,
+                              solver_kwargs=NamedTuple()) where {T<:AbstractFloat}
         n_draws, n_params = size(theta_draws)
         @assert length(log_posterior) == n_draws "log_posterior length must match n_draws"
         @assert length(param_names) == n_params "param_names length must match n_params"
         @assert method in (:smc, :rwmh, :csmc, :smc2, :importance) "unknown method: $method"
+        me = measurement_error === nothing ? nothing : Vector{T}(measurement_error)
         new{T}(theta_draws, log_posterior, param_names, priors,
                log_marginal_likelihood, method, acceptance_rate,
-               ess_history, phi_schedule, spec, solution, state_space)
+               ess_history, phi_schedule, spec, solution, state_space,
+               Matrix{T}(data), Vector{Symbol}(observables), me,
+               solver, solver_kwargs)
     end
 end
 

--- a/src/dsge/identification.jl
+++ b/src/dsge/identification.jl
@@ -1,0 +1,457 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+"""
+Identification diagnostics for DSGE models.
+
+Provides:
+- `identification_diagnostics` — Iskrev (2010) local-identification rank test
+  on the Jacobian of observable means + autocovariances w.r.t. the parameters
+- `learning_rate_check` — Koop-Pesaran-Smith (2013) posterior-variance
+  learning-rate check across nested subsamples
+- `prior_posterior_overlap` — prior/posterior overlap coefficients flagging
+  parameters whose posterior is essentially the prior
+
+References:
+- Iskrev, N. (2010). Local Identification in DSGE Models.
+  *Journal of Monetary Economics*, 57(2), 189-202.
+- Koop, G., Pesaran, M. H. & Smith, R. P. (2013). On Identification of
+  Bayesian DSGE Models. *Journal of Business & Economic Statistics*, 31(3).
+"""
+
+# =============================================================================
+# Iskrev (2010) rank test
+# =============================================================================
+
+"""
+    IdentificationDiagnostics{T}
+
+Result of the Iskrev (2010) local-identification rank test.
+
+Fields:
+- `param_names::Vector{Symbol}` — parameters checked
+- `theta::Vector{T}` — evaluation point
+- `rank::Int` — numerical rank of the moment Jacobian `J(θ)`
+- `n_params::Int` — number of parameters (full column rank required)
+- `n_moments::Int` — number of differentiated moments
+- `n_lags::Int` — autocovariance lags included in the moment vector
+- `singular_values::Vector{T}` — singular values of `J(θ)`
+- `tol::T` — rank tolerance used (relative to the largest singular value)
+- `null_space::Matrix{T}` — `n_params × k` basis of unidentified directions
+  (empty when identified)
+- `identified::Bool` — `rank == n_params`
+"""
+struct IdentificationDiagnostics{T<:AbstractFloat}
+    param_names::Vector{Symbol}
+    theta::Vector{T}
+    rank::Int
+    n_params::Int
+    n_moments::Int
+    n_lags::Int
+    singular_values::Vector{T}
+    tol::T
+    null_space::Matrix{T}
+    identified::Bool
+end
+
+"""
+    _identification_moments(spec, param_names, theta, observables, n_lags, solver,
+                            solver_kwargs) → Vector or nothing
+
+Iskrev moment map `m(θ)`: observable steady-state means, the lower triangle of
+the contemporaneous covariance, and the full autocovariance matrices at lags
+`1..n_lags` of the observables, computed from the first-order solution via the
+discrete Lyapunov equation. Returns `nothing` when the model fails to solve.
+"""
+function _identification_moments(spec::DSGESpec{T}, param_names::Vector{Symbol},
+                                 theta::AbstractVector{T},
+                                 observables::Vector{Symbol}, n_lags::Int,
+                                 solver::Symbol,
+                                 solver_kwargs::NamedTuple) where {T<:AbstractFloat}
+    try
+        new_pv = copy(spec.param_values)
+        for (i, pn) in enumerate(param_names)
+            new_pv[pn] = theta[i]
+        end
+        new_spec = _respec(spec, new_pv)
+        new_spec = compute_steady_state(new_spec)
+        sol = solve(new_spec; method=solver, solver_kwargs...)
+        is_determined(sol) || return nothing
+
+        G1 = Matrix{T}(sol.G1)
+        impact = Matrix{T}(sol.impact)
+        obs_idx = [findfirst(==(o), new_spec.endog) for o in observables]
+
+        # Effective mean of the observables (linear=true constant models included)
+        ss = if new_spec.linear && !all(iszero, sol.C_sol)
+            (I - G1) \ sol.C_sol
+        else
+            new_spec.steady_state
+        end
+
+        Sigma = solve_lyapunov(G1, impact)
+        n_o = length(obs_idx)
+
+        m = T[]
+        append!(m, T[ss[j] for j in obs_idx])
+        S0 = Sigma[obs_idx, obs_idx]
+        for i in 1:n_o, j in i:n_o
+            push!(m, S0[i, j])
+        end
+        Gh = Sigma
+        for _ in 1:n_lags
+            Gh = G1 * Gh                       # Γ_h = G1^h Σ
+            Sh = Gh[obs_idx, obs_idx]
+            append!(m, vec(Sh))
+        end
+        return m
+    catch
+        return nothing
+    end
+end
+
+"""
+    identification_diagnostics(spec, param_names; theta=nothing,
+                               observables=Symbol[], n_lags=2,
+                               tol_rel=sqrt(eps()), solver=:gensys,
+                               solver_kwargs=NamedTuple()) → IdentificationDiagnostics
+
+Iskrev (2010) local-identification rank test at the point `θ`.
+
+Builds the Jacobian `J(θ) = ∂m(θ)/∂θ'` of the **data moments** — the observable
+steady-state means, contemporaneous covariance (lower triangle), and the
+autocovariance matrices at lags `1..n_lags` computed from the first-order
+state-space solution — by central finite differences, then inspects its column
+rank via SVD. The parameters are locally identified from these moments iff
+`J(θ)` has full column rank. When rank-deficient, the right null space of `J`
+names the unidentified parameter directions, and a warning lists the involved
+parameters.
+
+Increase `n_lags` until `n_moments ≥ n_params` with slack; Iskrev recommends
+checking several lag horizons.
+
+# Arguments
+- `spec::DSGESpec` — model specification
+- `param_names::Vector{Symbol}` — parameters to check
+
+# Keywords
+- `theta=nothing` — evaluation point (default: the spec's current parameter values)
+- `observables::Vector{Symbol}=Symbol[]` — observed variables (default: all endogenous)
+- `n_lags::Int=2` — autocovariance lags in the moment vector
+- `tol_rel::Real=sqrt(eps())` — rank tolerance relative to the largest singular value
+- `solver::Symbol=:gensys`, `solver_kwargs::NamedTuple=()` — solution method
+
+# References
+- Iskrev, N. (2010). Local Identification in DSGE Models. *JME*, 57(2).
+"""
+function identification_diagnostics(spec::DSGESpec{T}, param_names::Vector{Symbol};
+                                    theta::Union{Nothing,AbstractVector{<:Real}}=nothing,
+                                    observables::Vector{Symbol}=Symbol[],
+                                    n_lags::Int=2,
+                                    tol_rel::Real=sqrt(eps(Float64)),
+                                    solver::Symbol=:gensys,
+                                    solver_kwargs::NamedTuple=NamedTuple()) where {T<:AbstractFloat}
+    d = length(param_names)
+    d > 0 || throw(ArgumentError("param_names must be non-empty"))
+    theta_v = theta === nothing ? T[spec.param_values[p] for p in param_names] : T.(theta)
+    length(theta_v) == d ||
+        throw(ArgumentError("theta has length $(length(theta_v)), expected $d"))
+    if isempty(observables)
+        observables = copy(spec.endog)
+    end
+    for o in observables
+        o in spec.endog ||
+            throw(ArgumentError("observable :$o is not an endogenous variable of the spec"))
+    end
+
+    m0 = _identification_moments(spec, param_names, theta_v, observables, n_lags,
+                                 solver, solver_kwargs)
+    m0 === nothing &&
+        throw(ArgumentError("model does not solve at θ = $theta_v; cannot run the rank test"))
+    n_m = length(m0)
+
+    # Jacobian by ForwardDiff where possible, central differences otherwise
+    moment_map = th -> begin
+        m = _identification_moments(spec, param_names, Vector{T}(th), observables,
+                                    n_lags, solver, solver_kwargs)
+        m === nothing ? fill(T(NaN), n_m) : m
+    end
+    J = try
+        ForwardDiff.jacobian(moment_map, theta_v)
+    catch
+        step = T(1e-6) * max(one(T), maximum(abs, theta_v))
+        numerical_gradient(moment_map, theta_v; eps=step)
+    end
+    all(isfinite, J) ||
+        throw(ArgumentError("moment Jacobian contains non-finite entries — the model " *
+                            "fails to solve in a neighborhood of θ; move θ inside the " *
+                            "determinacy region"))
+
+    F = svd(Matrix{T}(J); full=true)           # full V so the null space is complete
+    sv = F.S
+    tol = T(tol_rel) * (isempty(sv) ? one(T) : maximum(sv))
+    r = count(>(tol), sv)
+    # Right null space: columns of V for singular values ≤ tol (plus missing ones
+    # when n_moments < n_params)
+    null_cols = [k for k in 1:d if k > length(sv) || sv[k] <= tol]
+    Nsp = Matrix{T}(F.V[:, null_cols])
+
+    ident = r == d
+    if !ident
+        involved = Set{Symbol}()
+        for c in 1:size(Nsp, 2)
+            w = abs.(Nsp[:, c])
+            thr = T(0.1) * maximum(w)
+            for i in 1:d
+                w[i] >= thr && push!(involved, param_names[i])
+            end
+        end
+        @warn "identification_diagnostics: rank(J) = $r < $d — parameter(s) " *
+              join(sort!(collect(string.(involved))), ", ") *
+              " appear locally unidentified from the chosen observables/moments " *
+              "(Iskrev 2010)"
+    end
+
+    return IdentificationDiagnostics{T}(copy(param_names), theta_v, r, d, n_m,
+                                        n_lags, Vector{T}(sv), tol, Nsp, ident)
+end
+
+function Base.show(io::IO, idd::IdentificationDiagnostics{T}) where {T}
+    header = Any[
+        "Parameters"           idd.n_params;
+        "Moments"              idd.n_moments;
+        "Autocov. lags"        idd.n_lags;
+        "rank(J)"              idd.rank;
+        "Smallest sing. value" round(minimum(idd.singular_values); sigdigits=4);
+        "Rank tolerance"       round(idd.tol; sigdigits=4);
+        "Locally identified"   idd.identified ? "yes" : "NO";
+    ]
+    _pretty_table(io, header;
+        title="Iskrev (2010) Identification Rank Test",
+        column_labels=["", ""],
+        alignment=[:l, :r])
+
+    if !idd.identified
+        for c in 1:size(idd.null_space, 2)
+            w = idd.null_space[:, c]
+            thr = 0.1 * maximum(abs, w)
+            parts = String[]
+            for i in 1:idd.n_params
+                abs(w[i]) >= thr &&
+                    push!(parts, "$(round(w[i]; digits=3))·$(idd.param_names[i])")
+            end
+            println(io, "Unidentified direction $c: ", join(parts, " + "))
+        end
+    end
+end
+
+# =============================================================================
+# Koop-Pesaran-Smith (2013) learning-rate check
+# =============================================================================
+
+"""
+    LearningRateCheck{T}
+
+Result of the Koop-Pesaran-Smith (2013) posterior-variance learning-rate check.
+
+Fields:
+- `param_names::Vector{Symbol}` — parameters checked
+- `sample_sizes::Vector{Int}` — nested subsample sizes used
+- `post_vars::Matrix{T}` — n_params × n_subsamples posterior variances
+- `learning_rate::Vector{T}` — estimated rate `α` in `var ∝ T^{-α}` per parameter
+- `flagged::Vector{Bool}` — `α < threshold` (posterior barely updates with T)
+- `threshold::T` — flag threshold
+"""
+struct LearningRateCheck{T<:AbstractFloat}
+    param_names::Vector{Symbol}
+    sample_sizes::Vector{Int}
+    post_vars::Matrix{T}
+    learning_rate::Vector{T}
+    flagged::Vector{Bool}
+    threshold::T
+end
+
+"""
+    learning_rate_check(result::BayesianDSGE; fractions=[0.5, 1.0], n_smc=300,
+                        threshold=0.2, rng=Random.default_rng()) → LearningRateCheck
+
+Koop-Pesaran-Smith (2013) identification check: for an identified parameter the
+posterior variance shrinks at the `1/T` rate, so re-estimating on nested
+subsamples `⌊f·T⌋` and regressing `log var` on `log T` should give a slope near
+`−1`. A weakly identified parameter's posterior barely updates (`α ≈ 0`).
+
+Each subsample is re-estimated with a fresh SMC run (`n_smc` particles) using
+the stored estimation context, so the variances are comparable across sample
+sizes regardless of the original sampler. Parameters with `α < threshold` are
+flagged with a warning. This is a Monte Carlo procedure — expect noise in `α`;
+it is a screening device, not a hypothesis test.
+
+# References
+- Koop, G., Pesaran, M. H. & Smith, R. P. (2013). *JBES*, 31(3), 300-314.
+"""
+function learning_rate_check(result::BayesianDSGE{T};
+                             fractions::Vector{<:Real}=[0.5, 1.0],
+                             n_smc::Int=300,
+                             threshold::Real=0.2,
+                             rng::AbstractRNG=Random.default_rng()) where {T<:AbstractFloat}
+    isempty(result.data) &&
+        throw(ArgumentError("result carries no estimation data (hand-constructed?); " *
+                            "learning_rate_check needs the stored sample"))
+    length(fractions) >= 2 ||
+        throw(ArgumentError("need at least two subsample fractions"))
+    fr = sort(T.(fractions))
+    (first(fr) > 0 && last(fr) <= 1) ||
+        throw(ArgumentError("fractions must lie in (0, 1]"))
+
+    T_obs = size(result.data, 2)
+    d = length(result.param_names)
+    priors_dict = Dict{Symbol,Distribution}(result.param_names[i] =>
+        result.priors.distributions[i] for i in 1:d)
+    theta0 = vec(mean(result.theta_draws; dims=1))
+
+    sizes = [max(2 * d + 2, floor(Int, f * T_obs)) for f in fr]
+    post_vars = zeros(T, d, length(fr))
+    for (k, Tk) in enumerate(sizes)
+        sub = result.data[:, 1:Tk]
+        fit = estimate_dsge_bayes(result.spec, sub, theta0;
+                                  priors=priors_dict, method=:smc, n_smc=n_smc,
+                                  observables=result.observables,
+                                  measurement_error=result.measurement_error,
+                                  solver=result.solver,
+                                  solver_kwargs=result.solver_kwargs, rng=rng)
+        post_vars[:, k] = [var(fit.theta_draws[:, i]) for i in 1:d]
+    end
+
+    # Slope of log var on log T (least squares over the subsamples), α = −slope
+    lt = log.(T.(sizes))
+    lt_c = lt .- mean(lt)
+    denom = sum(abs2, lt_c)
+    alpha = zeros(T, d)
+    for i in 1:d
+        lv = log.(max.(post_vars[i, :], floatmin(T)))
+        alpha[i] = -sum(lt_c .* (lv .- mean(lv))) / denom
+    end
+
+    flagged = alpha .< T(threshold)
+    if any(flagged)
+        @warn "learning_rate_check: posterior variance of " *
+              join(string.(result.param_names[flagged]), ", ") *
+              " does not shrink with the sample size (α < $threshold) — " *
+              "weak identification suspected (Koop-Pesaran-Smith 2013)"
+    end
+
+    return LearningRateCheck{T}(copy(result.param_names), sizes, post_vars,
+                                alpha, Vector{Bool}(flagged), T(threshold))
+end
+
+function Base.show(io::IO, lrc::LearningRateCheck{T}) where {T}
+    d = length(lrc.param_names)
+    data = Matrix{Any}(undef, d, 3 + length(lrc.sample_sizes))
+    for i in 1:d
+        data[i, 1] = string(lrc.param_names[i])
+        for k in 1:length(lrc.sample_sizes)
+            data[i, 1+k] = round(lrc.post_vars[i, k]; sigdigits=4)
+        end
+        data[i, 2+length(lrc.sample_sizes)] = round(lrc.learning_rate[i]; digits=3)
+        data[i, 3+length(lrc.sample_sizes)] = lrc.flagged[i] ? "WEAK" : "ok"
+    end
+    _pretty_table(io, data;
+        title="Koop-Pesaran-Smith Learning-Rate Check (var ∝ T^-α; identified ⇒ α ≈ 1)",
+        column_labels=vcat(["Parameter"],
+                           ["var (T=$(t))" for t in lrc.sample_sizes],
+                           ["α", "Flag"]),
+        alignment=vcat([:l], fill(:r, length(lrc.sample_sizes) + 2)))
+end
+
+# =============================================================================
+# Prior/posterior overlap
+# =============================================================================
+
+"""
+    PriorPosteriorOverlap{T}
+
+Per-parameter prior/posterior overlap coefficients.
+
+Fields:
+- `param_names::Vector{Symbol}` — parameters
+- `overlap::Vector{T}` — overlap coefficient `∫ min(π(θ), p(θ|Y)) dθ ∈ [0, 1]`
+- `flagged::Vector{Bool}` — overlap ≥ threshold (posterior ≈ prior)
+- `threshold::T` — flag threshold
+"""
+struct PriorPosteriorOverlap{T<:AbstractFloat}
+    param_names::Vector{Symbol}
+    overlap::Vector{T}
+    flagged::Vector{Bool}
+    threshold::T
+end
+
+"""
+    prior_posterior_overlap(result::BayesianDSGE; n_grid=0, threshold=0.8)
+        → PriorPosteriorOverlap
+
+Overlap coefficient `∫ min(π(θᵢ), p(θᵢ|Y)) dθᵢ` between each parameter's prior
+density and its posterior marginal (histogram estimate on a common grid;
+`n_grid=0` picks `≈√N` bins so the histogram density is smooth at the available
+draw count). An overlap near 1 means the data barely moved the prior — the
+practical symptom of weak identification. Parameters with overlap ≥ `threshold`
+are flagged with a warning.
+"""
+function prior_posterior_overlap(result::BayesianDSGE{T};
+                                 n_grid::Int=0,
+                                 threshold::Real=0.8) where {T<:AbstractFloat}
+    d = length(result.param_names)
+    n_draws = size(result.theta_draws, 1)
+    if n_grid <= 0
+        n_grid = clamp(round(Int, sqrt(n_draws)), 10, 512)
+    end
+    ovl = zeros(T, d)
+    for i in 1:d
+        draws = result.theta_draws[:, i]
+        dist = result.priors.distributions[i]
+        lo = min(T(quantile(dist, 0.001)), minimum(draws))
+        hi = max(T(quantile(dist, 0.999)), maximum(draws))
+        hi > lo || (ovl[i] = one(T); continue)
+        edges = range(lo, hi; length=n_grid + 1)
+        width = step(edges)
+        counts = zeros(T, n_grid)
+        for x in draws
+            b = clamp(1 + floor(Int, (x - lo) / width), 1, n_grid)
+            counts[b] += 1
+        end
+        counts ./= (length(draws) * width)      # posterior density estimate
+        s = zero(T)
+        for b in 1:n_grid
+            c = (edges[b] + edges[b+1]) / 2
+            s += min(counts[b], T(pdf(dist, c))) * width
+        end
+        ovl[i] = min(s, one(T))
+    end
+
+    flagged = ovl .>= T(threshold)
+    if any(flagged)
+        @warn "prior_posterior_overlap: posterior of " *
+              join(string.(result.param_names[flagged]), ", ") *
+              " is essentially the prior (overlap ≥ $threshold) — the data are " *
+              "not informative about these parameters"
+    end
+
+    return PriorPosteriorOverlap{T}(copy(result.param_names), ovl,
+                                    Vector{Bool}(flagged), T(threshold))
+end
+
+function Base.show(io::IO, ppo::PriorPosteriorOverlap{T}) where {T}
+    d = length(ppo.param_names)
+    data = Matrix{Any}(undef, d, 3)
+    for i in 1:d
+        data[i, 1] = string(ppo.param_names[i])
+        data[i, 2] = round(ppo.overlap[i]; digits=3)
+        data[i, 3] = ppo.flagged[i] ? "WEAK" : "ok"
+    end
+    _pretty_table(io, data;
+        title="Prior/Posterior Overlap (≥ $(ppo.threshold) ⇒ data uninformative)",
+        column_labels=["Parameter", "Overlap", "Flag"],
+        alignment=[:l, :r, :r])
+end

--- a/src/dsge/mcmc_diagnostics.jl
+++ b/src/dsge/mcmc_diagnostics.jl
@@ -1,0 +1,398 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+"""
+MCMC convergence diagnostics for Bayesian DSGE chains.
+
+Provides:
+- `mcmc_diagnostics` — per-parameter rank-normalized split-R̂, bulk/tail ESS
+  (Vehtari et al. 2021), and Geweke (1992) z-statistics
+- `trace` — per-parameter draw sequence accessor
+- `acf(result, param)` — autocorrelation accessor reusing the spectral `acf`
+
+References:
+- Vehtari, A., Gelman, A., Simpson, D., Carpenter, B. & Bürkner, P.-C. (2021).
+  Rank-Normalization, Folding, and Localization: An Improved R̂ for Assessing
+  Convergence of MCMC. *Bayesian Analysis*, 16(2), 667-718.
+- Geweke, J. (1992). Evaluating the Accuracy of Sampling-Based Approaches to the
+  Calculation of Posterior Moments. In *Bayesian Statistics 4*.
+- Geyer, C. J. (1992). Practical Markov Chain Monte Carlo. *Statistical Science*,
+  7(4), 473-483.
+"""
+
+# =============================================================================
+# Rank normalization + chain splitting (Vehtari et al. 2021)
+# =============================================================================
+
+"""
+    _tied_ranks(v::AbstractVector{T}) → Vector{T}
+
+Average ranks (ties share the mean rank), 1-based.
+"""
+function _tied_ranks(v::AbstractVector{T}) where {T<:AbstractFloat}
+    n = length(v)
+    idx = sortperm(v)
+    ranks = zeros(T, n)
+    i = 1
+    while i <= n
+        j = i
+        while j < n && v[idx[j+1]] == v[idx[i]]
+            j += 1
+        end
+        avg = T(i + j) / 2
+        for k in i:j
+            ranks[idx[k]] = avg
+        end
+        i = j + 1
+    end
+    return ranks
+end
+
+"""
+    _rank_normalize(x::AbstractMatrix{T}) → Matrix{T}
+
+Rank-normalize pooled draws (N × M, draws × chains): rank across ALL draws,
+then map to z-scores via `Φ⁻¹((r − 3/8)/(S + 1/4))` (Blom offsets).
+"""
+function _rank_normalize(x::AbstractMatrix{T}) where {T<:AbstractFloat}
+    S = length(x)
+    r = _tied_ranks(vec(x))
+    z = [T(quantile(Normal(), (r[i] - T(3) / 8) / (S + T(1) / 4))) for i in eachindex(r)]
+    return reshape(z, size(x))
+end
+
+"""
+    _split_chain(x::AbstractVector{T}) → Matrix{T}
+
+Split a single chain into two half-chains (N÷2 × 2), dropping the middle draw
+when the length is odd.
+"""
+function _split_chain(x::AbstractVector{T}) where {T<:AbstractFloat}
+    N = length(x) ÷ 2
+    return hcat(x[1:N], x[end-N+1:end])
+end
+
+# =============================================================================
+# Split-R̂ and ESS on prepared (split, possibly rank-normalized) chains
+# =============================================================================
+
+"""
+    _rhat_chains(z::AbstractMatrix{T}) → T
+
+Potential scale reduction factor `√(var⁺/W)` for an N × M draws-by-chains
+matrix. Returns `NaN` for degenerate input (N < 4 or zero within-variance).
+"""
+function _rhat_chains(z::AbstractMatrix{T}) where {T<:AbstractFloat}
+    N, M = size(z)
+    (N < 4 || M < 2) && return T(NaN)
+    chain_means = vec(mean(z; dims=1))
+    W = mean(vec(var(z; dims=1)))
+    W > 0 || return T(NaN)
+    B_over_N = var(chain_means)
+    var_plus = (N - 1) / T(N) * W + B_over_N
+    return sqrt(var_plus / W)
+end
+
+"""
+    _ess_chains(z::AbstractMatrix{T}) → T
+
+Effective sample size for an N × M draws-by-chains matrix via the multi-chain
+autocorrelation estimate with Geyer's initial-monotone-sequence truncation
+(Vehtari et al. 2021, §3.2; matches Stan's `compute_effective_sample_size`).
+"""
+function _ess_chains(z::AbstractMatrix{T}) where {T<:AbstractFloat}
+    N, M = size(z)
+    N < 4 && return T(NaN)
+
+    # Per-chain biased autocovariances (denominator N), computed on demand
+    mus = vec(mean(z; dims=1))
+    function acov_lag(t::Int)
+        s = zero(T)
+        for m in 1:M
+            zm = @view z[:, m]
+            mu = mus[m]
+            a = zero(T)
+            @inbounds for i in 1:(N-t)
+                a += (zm[i] - mu) * (zm[i+t] - mu)
+            end
+            s += a / N
+        end
+        return s / M
+    end
+
+    acov0 = acov_lag(0)
+    acov0 > 0 || return T(NaN)
+    W = acov0 * N / (N - 1)                    # mean within-chain variance
+    chain_means = vec(mean(z; dims=1))
+    B_over_N = M > 1 ? var(chain_means) : zero(T)
+    var_plus = (N - 1) / T(N) * W + B_over_N
+    var_plus > 0 || return T(NaN)
+
+    rho = zeros(T, N)
+    rho[1] = one(T)                            # ρ̂_0
+    rho[2] = 1 - (W - acov_lag(1)) / var_plus  # ρ̂_1
+    rho_even, rho_odd = rho[1], rho[2]
+    t = 0
+    while t < N - 4 && rho_even + rho_odd > 0
+        t += 2
+        rho_even = 1 - (W - acov_lag(t)) / var_plus
+        rho_odd = 1 - (W - acov_lag(t + 1)) / var_plus
+        if rho_even + rho_odd >= 0
+            rho[t+1] = rho_even
+            rho[t+2] = rho_odd
+        end
+    end
+    max_t = t
+
+    # Geyer initial monotone sequence: successive pair sums non-increasing
+    for k in 2:2:(max_t-2)
+        if rho[k+1] + rho[k+2] > rho[k-1] + rho[k]
+            rho[k+1] = (rho[k-1] + rho[k]) / 2
+            rho[k+2] = rho[k+1]
+        end
+    end
+
+    S = T(N * M)
+    tau_hat = -1 + 2 * sum(@view rho[1:max_t]) + rho[max_t+1]
+    tau_hat = max(tau_hat, one(T) / log10(S))  # antithetic-chain guard
+    return S / tau_hat
+end
+
+# =============================================================================
+# Public per-vector diagnostics (single chain → split + rank-normalize)
+# =============================================================================
+
+"""
+    _rhat_rank(x::AbstractVector{T}) → T
+
+Rank-normalized split-R̂ of a single chain: the maximum of the split-R̂ on the
+rank-normalized draws and on the rank-normalized folded draws `|x − median|`
+(catches scale, not just location, non-convergence).
+"""
+function _rhat_rank(x::AbstractVector{T}) where {T<:AbstractFloat}
+    length(x) < 8 && return T(NaN)
+    z_bulk = _rank_normalize(_split_chain(x))
+    folded = abs.(x .- median(x))
+    z_fold = _rank_normalize(_split_chain(folded))
+    return max(_rhat_chains(z_bulk), _rhat_chains(z_fold))
+end
+
+"""
+    _ess_bulk(x::AbstractVector{T}) → T
+
+Bulk-ESS: ESS of the rank-normalized split chain (Vehtari et al. 2021).
+"""
+function _ess_bulk(x::AbstractVector{T}) where {T<:AbstractFloat}
+    length(x) < 8 && return T(NaN)
+    return _ess_chains(_rank_normalize(_split_chain(x)))
+end
+
+"""
+    _ess_tail(x::AbstractVector{T}) → T
+
+Tail-ESS: minimum ESS of the 5% and 95% quantile-exceedance indicators
+(Vehtari et al. 2021).
+"""
+function _ess_tail(x::AbstractVector{T}) where {T<:AbstractFloat}
+    length(x) < 8 && return T(NaN)
+    ess_q = map((T(0.05), T(0.95))) do q
+        cutoff = quantile(x, q)
+        _ess_chains(_split_chain(T.(x .<= cutoff)))
+    end
+    return min(ess_q...)
+end
+
+"""
+    _geweke_nse(x::AbstractVector{T}) → T
+
+Numerical standard error of the mean via a Bartlett-window (Newey-West)
+spectral density estimate at frequency zero.
+"""
+function _geweke_nse(x::AbstractVector{T}) where {T<:AbstractFloat}
+    n = length(x)
+    mu = mean(x)
+    L = min(n - 1, max(1, floor(Int, 4 * (n / 100)^(T(2) / 9))))
+    g0 = sum(abs2, x .- mu) / n
+    s = g0
+    for k in 1:L
+        gk = zero(T)
+        @inbounds for i in 1:(n-k)
+            gk += (x[i+k] - mu) * (x[i] - mu)
+        end
+        gk /= n
+        s += 2 * (1 - T(k) / (L + 1)) * gk
+    end
+    return sqrt(max(s, zero(T)) / n)
+end
+
+"""
+    _geweke_z(x::AbstractVector{T}; first=0.1, last=0.5) → T
+
+Geweke (1992) convergence z-statistic comparing the mean of the first `first`
+fraction of the chain against the last `last` fraction, with spectral (NSE)
+variance estimates. Under convergence, z ~ N(0,1).
+"""
+function _geweke_z(x::AbstractVector{T}; first::Real=0.1, last::Real=0.5) where {T<:AbstractFloat}
+    n = length(x)
+    n1 = max(2, floor(Int, first * n))
+    n2 = max(2, floor(Int, last * n))
+    n1 + n2 <= n || return T(NaN)
+    xa = @view x[1:n1]
+    xb = @view x[(n-n2+1):n]
+    denom = sqrt(_geweke_nse(xa)^2 + _geweke_nse(xb)^2)
+    denom > 0 || return T(NaN)
+    return (mean(xa) - mean(xb)) / denom
+end
+
+# =============================================================================
+# MCMCDiagnostics result + public API
+# =============================================================================
+
+"""
+    MCMCDiagnostics{T}
+
+Per-parameter MCMC convergence diagnostics for a `BayesianDSGE` chain.
+
+Fields:
+- `param_names::Vector{Symbol}` — parameter names
+- `rhat::Vector{T}` — rank-normalized split-R̂ (max of bulk and folded)
+- `ess_bulk::Vector{T}` — rank-normalized bulk effective sample size
+- `ess_tail::Vector{T}` — tail effective sample size (min of 5%/95% indicators)
+- `geweke_z::Vector{T}` — Geweke (1992) z-statistic (first 10% vs last 50%)
+- `geweke_p::Vector{T}` — two-sided p-value of the Geweke z
+- `mean::Vector{T}` — posterior mean per parameter
+- `sd::Vector{T}` — posterior standard deviation per parameter
+- `n_draws::Int` — number of retained (post-burn-in) draws
+- `method::Symbol` — sampler that produced the draws
+"""
+struct MCMCDiagnostics{T<:AbstractFloat}
+    param_names::Vector{Symbol}
+    rhat::Vector{T}
+    ess_bulk::Vector{T}
+    ess_tail::Vector{T}
+    geweke_z::Vector{T}
+    geweke_p::Vector{T}
+    mean::Vector{T}
+    sd::Vector{T}
+    n_draws::Int
+    method::Symbol
+end
+
+"""
+    mcmc_diagnostics(result::BayesianDSGE) → MCMCDiagnostics
+
+Compute per-parameter MCMC convergence diagnostics on the retained
+(post-burn-in) posterior draws:
+
+- **Rank-normalized split-R̂** (Vehtari et al. 2021): the chain is split in
+  half, pooled draws are rank-normalized (rank → z-score via the inverse normal
+  CDF with Blom offsets), and R̂ is the maximum of the bulk and folded
+  (`|θ − median|`) statistics. Values ≲ 1.01 indicate convergence.
+- **Bulk/tail ESS**: effective sample size from the integrated autocorrelation
+  time `ESS = S / (1 + 2Σ ρ̂ₖ)` with Geyer's initial-monotone-sequence
+  truncation; bulk on rank-normalized draws, tail as the minimum ESS of the
+  5% / 95% quantile indicators. Vehtari et al. recommend ESS ≥ 400.
+- **Geweke z**: spectral test comparing the mean of the first 10% vs the last
+  50% of the chain; |z| > 1.96 flags non-convergence at the 5% level.
+
+Diagnostics assume Markov chain draws — for `:smc`/`:smc2` results (weighted
+particle systems, not chains) a warning is emitted and autocorrelation-based
+quantities should be interpreted with caution.
+
+# Example
+```julia
+fit = estimate_dsge_bayes(spec, data, θ0; priors=priors, method=:mh)
+diag = mcmc_diagnostics(fit)
+diag.rhat, diag.ess_bulk
+```
+
+# References
+- Vehtari, A. et al. (2021). Rank-Normalization, Folding, and Localization:
+  An Improved R̂ for Assessing Convergence of MCMC. *Bayesian Analysis*, 16(2).
+- Geweke, J. (1992). In *Bayesian Statistics 4*.
+"""
+function mcmc_diagnostics(result::BayesianDSGE{T}) where {T<:AbstractFloat}
+    if result.method != :rwmh
+        @warn "mcmc_diagnostics: draws come from method=$(result.method) (weighted " *
+              "particles, not a Markov chain); autocorrelation-based diagnostics " *
+              "are approximate"
+    end
+    n_params = length(result.param_names)
+    n_draws = size(result.theta_draws, 1)
+
+    rhat_v = zeros(T, n_params)
+    essb = zeros(T, n_params)
+    esst = zeros(T, n_params)
+    gz = zeros(T, n_params)
+    gp = zeros(T, n_params)
+    mu = zeros(T, n_params)
+    sd = zeros(T, n_params)
+
+    for i in 1:n_params
+        x = result.theta_draws[:, i]
+        rhat_v[i] = _rhat_rank(x)
+        essb[i] = _ess_bulk(x)
+        esst[i] = _ess_tail(x)
+        gz[i] = _geweke_z(x)
+        gp[i] = isfinite(gz[i]) ? 2 * (1 - cdf(Normal(), abs(gz[i]))) : T(NaN)
+        mu[i] = mean(x)
+        sd[i] = std(x)
+    end
+
+    return MCMCDiagnostics{T}(copy(result.param_names), rhat_v, essb, esst,
+                              gz, gp, mu, sd, n_draws, result.method)
+end
+
+"""
+    trace(result::BayesianDSGE, param::Symbol) → Vector
+
+Return the retained (post-burn-in) draw sequence for `param`, for trace plots
+and custom diagnostics.
+"""
+function trace(result::BayesianDSGE{T}, param::Symbol) where {T<:AbstractFloat}
+    i = findfirst(==(param), result.param_names)
+    i === nothing &&
+        throw(ArgumentError("unknown parameter :$param; available: $(result.param_names)"))
+    return result.theta_draws[:, i]
+end
+
+"""
+    acf(result::BayesianDSGE, param::Symbol; lags=0, conf_level=0.95) → ACFResult
+
+Autocorrelation function of the retained draw sequence for `param` (dispatches
+to the spectral [`acf`](@ref)); useful for assessing chain mixing.
+"""
+acf(result::BayesianDSGE, param::Symbol; kwargs...) = acf(trace(result, param); kwargs...)
+
+function Base.show(io::IO, d::MCMCDiagnostics{T}) where {T}
+    header = Any[
+        "Draws"        d.n_draws;
+        "Parameters"   length(d.param_names);
+        "Method"       string(d.method);
+    ]
+    _pretty_table(io, header;
+        title="MCMC Convergence Diagnostics",
+        column_labels=["", ""],
+        alignment=[:l, :r])
+
+    data = hcat([string(p) for p in d.param_names],
+                round.(d.mean; digits=4), round.(d.sd; digits=4),
+                round.(d.rhat; digits=4),
+                round.(d.ess_bulk; digits=1), round.(d.ess_tail; digits=1),
+                round.(d.geweke_z; digits=3), round.(d.geweke_p; digits=4))
+    _pretty_table(io, data;
+        title="Per-Parameter Diagnostics",
+        column_labels=["Parameter", "Mean", "Std", "R-hat", "ESS (bulk)",
+                       "ESS (tail)", "Geweke z", "Geweke p"],
+        alignment=[:l, :r, :r, :r, :r, :r, :r, :r])
+
+    bad_rhat = [string(d.param_names[i]) for i in eachindex(d.rhat)
+                if isfinite(d.rhat[i]) && d.rhat[i] > 1.01]
+    if !isempty(bad_rhat)
+        println(io, "Note: R-hat > 1.01 for: ", join(bad_rhat, ", "),
+                " — chains may not have converged (Vehtari et al. 2021).")
+    end
+end

--- a/src/dsge/priors.jl
+++ b/src/dsge/priors.jl
@@ -1,0 +1,205 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+"""
+Dynare prior-convention shims.
+
+Published DSGE priors are almost always declared in Dynare's (mean, std)
+parameterization. `dynare_prior` converts those inputs into correctly
+parameterized `Distributions.jl` objects — including the inverse-gamma-on-σ
+(`InverseGamma1`) that naive use of `Distributions.InverseGamma` silently gets
+wrong.
+"""
+
+using Distributions: loggamma
+
+# =============================================================================
+# InverseGamma1 — Dynare's inv_gamma_pdf: inverse gamma on σ (not σ²)
+# =============================================================================
+
+"""
+    InverseGamma1(s, ν)
+
+Dynare's **type-1 inverse gamma**: the distribution of `σ` when
+`σ² ~ InverseGamma(ν/2, s/2)` (type-2 on the variance). This is the density
+behind Dynare's `inv_gamma_pdf` — it lives on the **standard deviation σ, not
+the variance σ²**. Passing Dynare `inv_gamma` numbers to
+`Distributions.InverseGamma` produces a completely different prior; use this
+type (or [`dynare_prior`](@ref)`(:inv_gamma, mean, std)`) instead.
+
+Density: `p(σ) ∝ σ^{-(ν+1)} exp(−s/(2σ²))` on `σ > 0`.
+
+Moments (for `ν > 2`):
+`E[σ] = √(s/2)·Γ((ν−1)/2)/Γ(ν/2)`, `E[σ²] = s/(ν−2)`.
+"""
+struct InverseGamma1{T<:Real} <: ContinuousUnivariateDistribution
+    s::T
+    nu::T
+    v::InverseGamma{T}   # distribution of σ²
+
+    function InverseGamma1{T}(s::T, nu::T) where {T<:Real}
+        s > 0 || throw(ArgumentError("InverseGamma1 scale s must be positive"))
+        nu > 0 || throw(ArgumentError("InverseGamma1 dof ν must be positive"))
+        new{T}(s, nu, InverseGamma(nu / 2, s / 2))
+    end
+end
+InverseGamma1(s::T, nu::T) where {T<:Real} = InverseGamma1{T}(s, nu)
+InverseGamma1(s::Real, nu::Real) = InverseGamma1(promote(float(s), float(nu))...)
+
+Distributions.minimum(::InverseGamma1{T}) where {T} = zero(T)
+Distributions.maximum(::InverseGamma1{T}) where {T} = T(Inf)
+Distributions.insupport(::InverseGamma1, x::Real) = x > 0
+
+function Distributions.logpdf(d::InverseGamma1{T}, x::Real) where {T}
+    x > 0 || return T(-Inf)
+    return logpdf(d.v, x^2) + log(2 * T(x))
+end
+Distributions.pdf(d::InverseGamma1, x::Real) = exp(logpdf(d, x))
+Distributions.cdf(d::InverseGamma1{T}, x::Real) where {T} =
+    x <= 0 ? zero(T) : cdf(d.v, T(x)^2)
+Distributions.quantile(d::InverseGamma1, p::Real) = sqrt(quantile(d.v, p))
+Base.rand(rng::AbstractRNG, d::InverseGamma1) = sqrt(rand(rng, d.v))
+
+function Statistics.mean(d::InverseGamma1{T}) where {T}
+    d.nu > 1 || return T(NaN)
+    return exp(log(d.s / 2) / 2 + loggamma((d.nu - 1) / 2) - loggamma(d.nu / 2))
+end
+function Statistics.var(d::InverseGamma1{T}) where {T}
+    d.nu > 2 || return T(NaN)
+    return d.s / (d.nu - 2) - mean(d)^2
+end
+Statistics.std(d::InverseGamma1) = sqrt(var(d))
+
+# =============================================================================
+# dynare_prior — (mean, std) constructors matching Dynare's pdf conventions
+# =============================================================================
+
+"""
+    _ig1_from_moments(m, sd) → InverseGamma1
+
+Solve Dynare's `(s, ν)` from the target mean `m` and std `sd` of σ. Uses
+`E[σ²] = s/(ν−2) = m² + sd²` to eliminate `s`, then bisects on `ν` so that
+`E[σ] = m`.
+"""
+function _ig1_from_moments(m::Float64, sd::Float64)
+    c = m^2 + sd^2
+    # E[σ](ν) with s = c(ν−2); monotone in ν from 0 (ν→2⁺) to √c (ν→∞)
+    mean_at = nu -> exp(log(c * (nu - 2) / 2) / 2 +
+                        loggamma((nu - 1) / 2) - loggamma(nu / 2))
+    lo, hi = 2.0 + 1e-10, 1e10
+    # expand hi is unnecessary: mean_at(hi) → √c > m guaranteed
+    for _ in 1:500
+        mid = (lo + hi) / 2
+        if mean_at(mid) < m
+            lo = mid
+        else
+            hi = mid
+        end
+        hi - lo < 1e-12 * hi && break
+    end
+    nu = (lo + hi) / 2
+    s = c * (nu - 2)
+    return InverseGamma1(s, nu)
+end
+
+"""
+    dynare_prior(dist::Symbol, mean, std; lower=nothing, upper=nothing) → Distribution
+
+Construct a prior from Dynare's (mean, std) convention, returning a correctly
+parameterized `Distributions.jl` object usable directly in the `priors` dict of
+[`estimate_dsge_bayes`](@ref) / [`posterior_mode`](@ref).
+
+| Dynare pdf | `dist` | Returns |
+|---|---|---|
+| `normal_pdf` | `:normal` | `Normal(mean, std)` |
+| `gamma_pdf` | `:gamma` | `Gamma(mean²/std², std²/mean)` |
+| `beta_pdf` | `:beta` | `Beta(α, β)` moment-matched; `(lower, upper)` gives Dynare's generalized `(p3, p4)` beta |
+| `inv_gamma_pdf` / `inv_gamma1_pdf` | `:inv_gamma` / `:inv_gamma1` | [`InverseGamma1`](@ref) **on σ** with the requested mean/std |
+| `inv_gamma2_pdf` | `:inv_gamma2` | `InverseGamma(α, β)` **on σ²** with the requested mean/std |
+| `uniform_pdf` | `:uniform` | `Uniform(a, b)`; pass `lower`/`upper` directly or derive from (mean, std) |
+
+!!! warning "Dynare's inverse gamma is on σ, not σ²"
+    Dynare's `inv_gamma_pdf` is the type-1 inverse gamma on the **standard
+    deviation**. `Distributions.InverseGamma` is on the **variance**. Feeding
+    Dynare's numbers to `Distributions.InverseGamma` — the natural-looking
+    thing to do — silently produces a completely different prior. This
+    constructor exists to prevent exactly that bug: `dynare_prior(:inv_gamma,
+    m, s)` returns a distribution whose draws are σ values with mean `m` and
+    std `s`.
+
+# Examples
+```julia
+priors = Dict(
+    :rho    => dynare_prior(:beta, 0.7, 0.1),          # persistence
+    :sigma  => dynare_prior(:inv_gamma, 0.02, 0.05),   # shock SD (σ-space!)
+    :phi    => dynare_prior(:gamma, 1.5, 0.25),        # elasticity
+    :alpha  => dynare_prior(:normal, 0.3, 0.05),
+    :theta  => dynare_prior(:beta, 0.5, 0.1; lower=0.0, upper=0.9),
+)
+```
+"""
+function dynare_prior(dist::Symbol, mean_v::Real, std_v::Real;
+                      lower::Union{Nothing,Real}=nothing,
+                      upper::Union{Nothing,Real}=nothing)
+    m = Float64(mean_v)
+    sd = Float64(std_v)
+
+    if dist == :normal
+        sd > 0 || throw(ArgumentError("normal prior needs std > 0"))
+        return Normal(m, sd)
+
+    elseif dist == :gamma
+        (m > 0 && sd > 0) || throw(ArgumentError("gamma prior needs mean > 0, std > 0"))
+        k = m^2 / sd^2
+        th = sd^2 / m
+        return Gamma(k, th)
+
+    elseif dist == :beta
+        a = lower === nothing ? 0.0 : Float64(lower)
+        b = upper === nothing ? 1.0 : Float64(upper)
+        b > a || throw(ArgumentError("beta prior needs upper > lower"))
+        mu = (m - a) / (b - a)
+        sig = sd / (b - a)
+        (0 < mu < 1) ||
+            throw(ArgumentError("beta prior mean must lie strictly inside ($a, $b)"))
+        sig^2 < mu * (1 - mu) ||
+            throw(ArgumentError("beta prior std too large: needs std² < mean(1−mean) " *
+                                "on the (lower, upper) scale"))
+        k0 = mu * (1 - mu) / sig^2 - 1
+        alpha = mu * k0
+        beta = (1 - mu) * k0
+        base = Beta(alpha, beta)
+        return (a == 0.0 && b == 1.0) ? base : a + (b - a) * base
+
+    elseif dist == :inv_gamma || dist == :inv_gamma1
+        (m > 0 && sd > 0) ||
+            throw(ArgumentError("inverse-gamma prior needs mean > 0, std > 0"))
+        return _ig1_from_moments(m, sd)
+
+    elseif dist == :inv_gamma2
+        (m > 0 && sd > 0) ||
+            throw(ArgumentError("inverse-gamma-2 prior needs mean > 0, std > 0"))
+        alpha = m^2 / sd^2 + 2
+        beta = m * (alpha - 1)
+        return InverseGamma(alpha, beta)
+
+    elseif dist == :uniform
+        if lower !== nothing || upper !== nothing
+            (lower !== nothing && upper !== nothing) ||
+                throw(ArgumentError("uniform prior needs both lower and upper"))
+            Float64(upper) > Float64(lower) ||
+                throw(ArgumentError("uniform prior needs upper > lower"))
+            return Uniform(Float64(lower), Float64(upper))
+        end
+        sd > 0 || throw(ArgumentError("uniform prior needs std > 0"))
+        half = sqrt(3.0) * sd
+        return Uniform(m - half, m + half)
+
+    else
+        throw(ArgumentError("unknown Dynare prior :$dist — use :normal, :gamma, " *
+                            ":beta, :inv_gamma (σ), :inv_gamma2 (σ²), or :uniform"))
+    end
+end

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -598,7 +598,13 @@ acceptance rate (Roberts & Rosenthal 2001).
   (`estimate_dsge_bayes`) discards the first `burnin` draws unless `keep_burnin=true`.
 - `adapt_interval::Int=100` — adapt proposal covariance every N draws
 - `init_proposal_cov::Union{Nothing,AbstractMatrix}=nothing` — initial proposal
-  covariance (already scaled, e.g. `c²·H⁻¹` from `posterior_mode`); default `c²·I`
+  covariance in the SAMPLING space (already scaled, e.g. `c²·H⁻¹` from
+  `posterior_mode`, transformed by the caller when `transform=true`); default `c²·I`
+- `transform::Bool=false` — random-walk in the prior-transformed unconstrained
+  space (log/logit via `ParameterTransform`): the target becomes
+  `log posterior(θ(y)) + log|J(y)|` so the θ-space posterior is preserved, no
+  proposal is ever wasted outside the support, and stored draws are
+  back-transformed to θ before being returned
 - `observables::Vector{Symbol}` — observed variables
 - `measurement_error` — measurement error SDs or `nothing`
 - `solver::Symbol=:gensys` — DSGE solver method
@@ -606,8 +612,9 @@ acceptance rate (Roberts & Rosenthal 2001).
 - `rng::AbstractRNG` — random number generator
 
 # Returns
-- `draws::Matrix{T}` — `n_draws × n_params` matrix of posterior draws
-- `log_posterior::Vector{T}` — log posterior at each draw
+- `draws::Matrix{T}` — `n_draws × n_params` matrix of posterior draws (θ-space)
+- `log_posterior::Vector{T}` — log posterior `log L + log π` at each draw
+  (θ-space kernel, no Jacobian, regardless of `transform`)
 - `acceptance_rate::T` — overall acceptance rate
 
 # References
@@ -620,6 +627,7 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                      n_draws::Int=5000, burnin::Int=1000,
                      adapt_interval::Int=100,
                      init_proposal_cov::Union{Nothing,AbstractMatrix}=nothing,
+                     transform::Bool=false,
                      observables::Vector{Symbol}=spec.endog,
                      measurement_error=nothing,
                      solver::Symbol=:gensys,
@@ -632,8 +640,24 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     ll_fn = _build_likelihood_fn(spec, param_names, data, observables,
                                   measurement_error, solver, solver_kwargs)
 
-    # Initialize
+    # Transform layer: the walk runs on x (= θ untransformed, or y = T(θ)
+    # unconstrained); acceptance uses log posterior(θ(x)) + log|J(x)|
+    pt = transform ? ParameterTransform(prior.lower, prior.upper) : nothing
+    to_nat = transform ? (x -> to_constrained(pt, x)) : identity
+    ljac = transform ? (x -> log_jacobian(pt, x)) : (x -> zero(T))
+
+    # Initialize (θ-space first, then map into the sampling space)
     theta_current = copy(theta0)
+    if transform
+        # Nudge strictly inside the support so the transform is finite
+        for i in 1:n_params
+            lo, hi = prior.lower[i], prior.upper[i]
+            span = isfinite(lo) && isfinite(hi) ? hi - lo : one(T)
+            margin = T(1e-8) * span
+            isfinite(lo) && theta_current[i] <= lo && (theta_current[i] = lo + margin)
+            isfinite(hi) && theta_current[i] >= hi && (theta_current[i] = hi - margin)
+        end
+    end
     ll_current = ll_fn(theta_current)
     lp_current = _log_prior(theta_current, prior)
 
@@ -656,12 +680,16 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
         end
     end
 
-    # Storage
+    x_current = transform ? to_unconstrained(pt, theta_current) : theta_current
+    lj_current = ljac(x_current)
+
+    # Storage: θ-space draws for the caller, sampling-space path for adaptation
     draws = zeros(T, n_draws, n_params)
     log_posterior = zeros(T, n_draws)
+    xs = transform ? zeros(T, n_draws, n_params) : draws
 
-    # Proposal covariance: caller-supplied (already scaled, e.g. c²·H⁻¹ from
-    # posterior_mode) or identity scaled by c²
+    # Proposal covariance: caller-supplied (already scaled and in the sampling
+    # space, e.g. c²·H⁻¹ from posterior_mode) or identity scaled by c²
     c2 = T(2.38)^2 / T(n_params)
     proposal_cov = init_proposal_cov === nothing ?
         c2 * Matrix{T}(I, n_params, n_params) : Matrix{T}(init_proposal_cov)
@@ -677,9 +705,10 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     total_accepted = 0
 
     for draw in 1:n_draws
-        # Propose
+        # Propose in the sampling space
         z = randn(rng, T, n_params)
-        theta_star = theta_current + scale_factor * proposal_L * z
+        x_star = x_current + scale_factor * proposal_L * z
+        theta_star = to_nat(x_star)
 
         # Evaluate
         lp_star = _log_prior(theta_star, prior)
@@ -688,27 +717,34 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
             ll_star = ll_fn(theta_star)
 
             if isfinite(ll_star)
-                # MH acceptance ratio (phi = 1 for full posterior)
-                log_alpha = (ll_star + lp_star) - (ll_current + lp_current)
+                lj_star = ljac(x_star)
+                # MH acceptance ratio; the Jacobian terms make the y-space walk
+                # target the pushforward of the θ-space posterior
+                log_alpha = (ll_star + lp_star + lj_star) -
+                            (ll_current + lp_current + lj_current)
 
                 if log(rand(rng, T)) < log_alpha
+                    x_current = x_star
                     theta_current = theta_star
                     ll_current = ll_star
                     lp_current = lp_star
+                    lj_current = lj_star
                     total_accepted += 1
                 end
             end
         end
 
-        # Store
+        # Store (θ-space kernel, no Jacobian — the convention downstream
+        # consumers like bridge_sampling_ml rely on)
         draws[draw, :] = theta_current
         log_posterior[draw] = ll_current + lp_current
+        transform && (xs[draw, :] = x_current)
 
-        # Adapt proposal covariance
+        # Adapt proposal covariance (in the sampling space)
         if draw % adapt_interval == 0 && draw >= 2 * adapt_interval
             # Use recent draws to update proposal covariance
             recent_start = max(1, draw - 5 * adapt_interval)
-            recent_draws = draws[recent_start:draw, :]
+            recent_draws = xs[recent_start:draw, :]
 
             if size(recent_draws, 1) > n_params + 1
                 sample_cov = cov(recent_draws)

--- a/src/dsge/smc.jl
+++ b/src/dsge/smc.jl
@@ -597,6 +597,8 @@ acceptance rate (Roberts & Rosenthal 2001).
 - `burnin::Int=1000` — burn-in length. `_mh_sample` returns the FULL chain; the caller
   (`estimate_dsge_bayes`) discards the first `burnin` draws unless `keep_burnin=true`.
 - `adapt_interval::Int=100` — adapt proposal covariance every N draws
+- `init_proposal_cov::Union{Nothing,AbstractMatrix}=nothing` — initial proposal
+  covariance (already scaled, e.g. `c²·H⁻¹` from `posterior_mode`); default `c²·I`
 - `observables::Vector{Symbol}` — observed variables
 - `measurement_error` — measurement error SDs or `nothing`
 - `solver::Symbol=:gensys` — DSGE solver method
@@ -617,6 +619,7 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
                      theta0::AbstractVector{T};
                      n_draws::Int=5000, burnin::Int=1000,
                      adapt_interval::Int=100,
+                     init_proposal_cov::Union{Nothing,AbstractMatrix}=nothing,
                      observables::Vector{Symbol}=spec.endog,
                      measurement_error=nothing,
                      solver::Symbol=:gensys,
@@ -657,13 +660,19 @@ function _mh_sample(spec::DSGESpec{T}, data::AbstractMatrix,
     draws = zeros(T, n_draws, n_params)
     log_posterior = zeros(T, n_draws)
 
-    # Proposal covariance: start with identity, scale by c²
+    # Proposal covariance: caller-supplied (already scaled, e.g. c²·H⁻¹ from
+    # posterior_mode) or identity scaled by c²
     c2 = T(2.38)^2 / T(n_params)
-    proposal_cov = c2 * Matrix{T}(I, n_params, n_params)
+    proposal_cov = init_proposal_cov === nothing ?
+        c2 * Matrix{T}(I, n_params, n_params) : Matrix{T}(init_proposal_cov)
     scale_factor = one(T)
 
     # Cholesky of proposal
-    proposal_L = cholesky(Hermitian(proposal_cov)).L
+    proposal_L = try
+        cholesky(Hermitian(proposal_cov)).L
+    catch
+        cholesky(Hermitian(proposal_cov + T(1e-8) * I)).L
+    end
 
     total_accepted = 0
 

--- a/src/gmm/transforms.jl
+++ b/src/gmm/transforms.jl
@@ -101,6 +101,44 @@ function to_constrained(pt::ParameterTransform{T}, phi::AbstractVector) where {T
 end
 
 """
+    _log1pexp(x) -> log(1 + exp(x)), numerically stable
+
+Stable softplus: returns `x` for large `x` (where `log1p(exp(x))` would overflow)
+and `log1p(exp(x))` otherwise.
+"""
+_log1pexp(x::T) where {T<:AbstractFloat} = x > T(35) ? x : log1p(exp(x))
+
+"""
+    log_jacobian(pt::ParameterTransform, phi::AbstractVector) -> T
+
+Summed log absolute Jacobian `Σᵢ log|dθᵢ/dφᵢ|` of the inverse transform
+(unconstrained → constrained) at `φ`, evaluated stably:
+
+- identity: `0`
+- `(a, ∞)` / `(-∞, b)` (exp-based): `φᵢ`
+- `(a, b)` (logistic): `log(b−a) − log(1+e^{−φᵢ}) − log(1+e^{φᵢ})`
+
+This is the Jacobian correction added to a log density when sampling in the
+unconstrained space (Stan reference manual, constrained-parameter transforms).
+"""
+function log_jacobian(pt::ParameterTransform{T}, phi::AbstractVector) where {T<:AbstractFloat}
+    lj = zero(T)
+    for i in eachindex(phi)
+        lo, hi = pt.lower[i], pt.upper[i]
+        p = T(phi[i])
+        if isinf(lo) && isinf(hi)
+            # identity: log|1| = 0
+        elseif isinf(hi) || isinf(lo)
+            # exp-based one-sided transforms: |dθ/dφ| = e^φ
+            lj += p
+        else
+            lj += log(hi - lo) - _log1pexp(-p) - _log1pexp(p)
+        end
+    end
+    return lj
+end
+
+"""
     transform_jacobian(pt::ParameterTransform, phi::AbstractVector) -> Matrix
 
 Diagonal Jacobian ∂θ/∂φ of the inverse transform (unconstrained → constrained).

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -2651,4 +2651,154 @@ end
     @test !(d_eff[1] ≈ 0.0)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Posterior mode + Laplace ML + mode-seeded RWMH proposal (T233 / #332)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "posterior_mode: mode finding + Laplace ML (#332)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    data = simulate(sol_true, 300; rng=rng)'
+
+    priors = Dict(:ρ => Beta(2, 2))
+
+    pm = posterior_mode(spec, data, [0.5]; priors=priors, observables=[:y])
+
+    @test pm isa PosteriorMode{Float64}
+    @test length(pm.mode) == 1
+    @test pm.param_names == [:ρ]
+    @test pm.converged
+    # Mode recovers the true ρ = 0.8 from T=300 simulated observations
+    @test abs(pm.mode[1] - 0.8) < 0.15
+    # Hessian/inverse-Hessian are PD scalars here
+    @test pm.hessian[1, 1] > 0
+    @test pm.inv_hessian[1, 1] > 0
+    @test pm.inv_hessian[1, 1] ≈ 1 / pm.hessian[1, 1] rtol=1e-6
+    @test isfinite(pm.log_posterior)
+    @test isfinite(pm.log_likelihood)
+    @test isfinite(pm.laplace_log_ml)
+    # Laplace ML must be below the log posterior maximum plus the Gaussian volume
+    # term only when det H > 1; sanity: it is finite and differs from log posterior
+    @test pm.laplace_log_ml != pm.log_posterior
+
+    # Mode is a maximizer: log posterior at the mode ≥ at nearby points
+    ll_fn = MacroEconometricModels._build_likelihood_fn(
+        spec, [:ρ], Matrix{Float64}(data), [:y], nothing, :gensys, NamedTuple())
+    prior = MacroEconometricModels._build_bayes_prior(priors)
+    lp(θ) = ll_fn([θ]) + MacroEconometricModels._log_prior([θ], prior)
+    @test pm.log_posterior ≥ lp(pm.mode[1] + 0.05) - 1e-8
+    @test pm.log_posterior ≥ lp(pm.mode[1] - 0.05) - 1e-8
+
+    # transform=false path reaches the same interior mode
+    pm2 = posterior_mode(spec, data, [0.5]; priors=priors, observables=[:y],
+                         transform=false)
+    @test abs(pm2.mode[1] - pm.mode[1]) < 0.02
+
+    # Laplace log-ML agrees with the SMC tempering-path log-ML (documented
+    # tolerance: 1.0 nat on this 1-parameter linear-Gaussian model)
+    smc_fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:smc, observables=[:y],
+        n_smc=300, rng=Random.MersenneTwister(11))
+    @test abs(pm.laplace_log_ml - marginal_likelihood(smc_fit)) < 1.0
+
+    # show does not error
+    io = IOBuffer()
+    show(io, pm)
+    out = String(take!(io))
+    @test occursin("Posterior Mode", out)
+    end
+end
+
+@testset "posterior_mode: RWMH proposal seeding (proposal=:mode)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    data = simulate(sol_true, 300; rng=rng)'
+
+    priors = Dict(:ρ => Beta(2, 2))
+
+    fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:mh, proposal=:mode,
+        n_draws=1500, burnin=500, observables=[:y],
+        rng=Random.MersenneTwister(7))
+
+    @test fit isa BayesianDSGE{Float64}
+    # Mode-seeded inverse-Hessian proposal achieves a reasonable acceptance rate
+    # (documented target 0.2–0.4; assert a safe envelope)
+    @test 0.10 < fit.acceptance_rate < 0.60
+    # Posterior mean near truth
+    @test abs(mean(fit.theta_draws[:, 1]) - 0.8) < 0.2
+
+    # Invalid proposal symbol throws
+    @test_throws ArgumentError estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:mh, proposal=:bogus,
+        n_draws=10, burnin=2, observables=[:y])
+    end
+end
+
+@testset "posterior_mode: non-PD Hessian fallback (flat posterior)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    # κ multiplies a zero regressor: the likelihood is flat in κ, and the
+    # Uniform(0,1) prior contributes zero curvature → H ≈ 0 → not PD
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5, κ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + κ * 0.0 * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sol = solve(spec; method=:gensys)
+    data = simulate(sol, 100; rng=rng)'
+
+    priors = Dict(:κ => Uniform(0.0, 1.0))
+    pm = @test_logs (:warn, r"not finite positive definite") match_mode=:any begin
+        posterior_mode(spec, data, [0.5]; priors=priors, observables=[:y])
+    end
+    @test isnan(pm.laplace_log_ml)
+    # Diagonal fallback proposal is still usable
+    @test isfinite(pm.inv_hessian[1, 1])
+    @test pm.inv_hessian[1, 1] > 0
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -2801,4 +2801,132 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# MCMC convergence diagnostics (T234 / #333)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "MCMC diagnostics internals: rank-normalized R̂/ESS/Geweke (#333)" begin
+    M = MacroEconometricModels
+    rng = Random.MersenneTwister(2026)
+
+    # Tied ranks average
+    @test M._tied_ranks([1.0, 2.0, 2.0, 3.0]) == [1.0, 2.5, 2.5, 4.0]
+
+    # Rank normalization: monotone, mean ≈ 0
+    z = M._rank_normalize(reshape(collect(1.0:100.0), 50, 2))
+    @test size(z) == (50, 2)
+    @test abs(mean(z)) < 1e-10
+    @test issorted(vec(z))
+
+    # iid chain: R̂ ≈ 1, ESS ≈ S, Geweke accepts
+    x = randn(rng, 4000)
+    @test M._rhat_rank(x) < 1.02
+    @test 0.5 * 4000 < M._ess_bulk(x) < 2.0 * 4000
+    @test M._ess_tail(x) > 400
+    @test abs(M._geweke_z(x)) < 3.5
+
+    # Sticky AR(1) chain (φ = 0.99): ESS collapses
+    y = zeros(4000)
+    for t in 2:4000
+        y[t] = 0.99 * y[t-1] + 0.1 * randn(rng)
+    end
+    @test M._ess_bulk(y) < 0.2 * 4000
+
+    # Drifting chain: Geweke rejects
+    drift = collect(range(0.0, 3.0; length=2000)) .+ 0.1 .* randn(rng, 2000)
+    @test abs(M._geweke_z(drift)) > 3.0
+
+    # Degenerate constant chain → NaN diagnostics (no crash)
+    @test isnan(M._ess_bulk(fill(1.0, 100)))
+    @test isnan(M._rhat_rank(fill(1.0, 100)))
+    @test isnan(M._ess_tail(fill(1.0, 100)))
+end
+
+@testset "mcmc_diagnostics + trace/acf accessors + low-ESS warning (#333)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    data = simulate(sol_true, 200; rng=rng)'
+
+    priors = Dict(:ρ => Beta(2, 2))
+    fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:mh, n_draws=2000, burnin=500,
+        observables=[:y], rng=Random.MersenneTwister(123))
+
+    # mcmc_diagnostics returns per-parameter stats on the retained chain
+    d = mcmc_diagnostics(fit)
+    @test d isa MCMCDiagnostics{Float64}
+    @test d.param_names == [:ρ]
+    @test d.n_draws == 1500                    # burnin discarded
+    @test isfinite(d.rhat[1])
+    @test d.rhat[1] < 1.2                      # short but reasonably mixed chain
+    @test 0 < d.ess_bulk[1] <= 1500 * log10(1500.0)
+    @test 0 < d.ess_tail[1]
+    @test isfinite(d.geweke_z[1])
+    @test 0 <= d.geweke_p[1] <= 1
+    @test abs(d.mean[1] - 0.8) < 0.3
+
+    # show does not error and prints the table
+    io = IOBuffer()
+    show(io, d)
+    out = String(take!(io))
+    @test occursin("R-hat", out)
+    @test occursin("ESS", out)
+
+    # trace accessor
+    tr = trace(fit, :ρ)
+    @test tr == fit.theta_draws[:, 1]
+    @test length(tr) == 1500
+    @test_throws ArgumentError trace(fit, :bogus)
+
+    # acf accessor dispatches to the spectral acf
+    a = acf(fit, :ρ; lags=10)
+    @test length(a.acf) == 10
+    @test all(abs.(a.acf) .<= 1.0 .+ 1e-12)
+
+    # low-ESS warning path: an impossible threshold forces the flag
+    ps = @test_logs (:warn, r"bulk ESS below") match_mode=:any begin
+        posterior_summary(fit; min_ess=10^9)
+    end
+    @test ps[:ρ][:low_ess] == 1.0
+    @test haskey(ps[:ρ], :ess_bulk)
+    pt = prior_posterior_table(fit; min_ess=10^9)
+    @test pt[1].low_ess === true
+
+    # relaxed threshold: no flag
+    ps0 = posterior_summary(fit; min_ess=0)
+    @test ps0[:ρ][:low_ess] == 0.0
+
+    # SMC results carry no ESS annotation (weighted particles, not a chain)
+    smc_fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:smc, n_smc=100,
+        observables=[:y], rng=Random.MersenneTwister(5))
+    pss = posterior_summary(smc_fit)
+    @test !haskey(pss[:ρ], :ess_bulk)
+    # mcmc_diagnostics on SMC draws warns but still computes
+    d2 = @test_logs (:warn, r"not a Markov chain") match_mode=:any begin
+        mcmc_diagnostics(smc_fit)
+    end
+    @test d2 isa MCMCDiagnostics{Float64}
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3309,4 +3309,130 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Dynare prior-convention shims (T239 / #338)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "dynare_prior: moment-matched constructors (#338)" begin
+    # normal — passthrough
+    d = dynare_prior(:normal, 0.3, 0.05)
+    @test d isa Normal
+    @test mean(d) ≈ 0.3 && std(d) ≈ 0.05
+
+    # gamma — k = m²/s², θ = s²/m
+    g = dynare_prior(:gamma, 1.5, 0.25)
+    @test g isa Gamma
+    @test mean(g) ≈ 1.5 atol=1e-12
+    @test std(g) ≈ 0.25 atol=1e-12
+    @test g.α ≈ 1.5^2 / 0.25^2 atol=1e-10
+
+    # beta — analytic shape parameters
+    b = dynare_prior(:beta, 0.7, 0.1)
+    @test b isa Beta
+    @test mean(b) ≈ 0.7 atol=1e-12
+    @test std(b) ≈ 0.1 atol=1e-12
+    k0 = 0.7 * 0.3 / 0.01 - 1
+    @test b.α ≈ 0.7 * k0 atol=1e-10
+    @test b.β ≈ 0.3 * k0 atol=1e-10
+
+    # generalized beta on (p3, p4) = (0, 0.9)
+    bs = dynare_prior(:beta, 0.5, 0.1; lower=0.0, upper=0.9)
+    @test mean(bs) ≈ 0.5 atol=1e-10
+    @test std(bs) ≈ 0.1 atol=1e-10
+    @test minimum(bs) ≈ 0.0 atol=1e-12
+    @test maximum(bs) ≈ 0.9 atol=1e-12
+
+    # uniform — from (mean, std) or explicit (lower, upper)
+    u = dynare_prior(:uniform, 0.5, 0.1)
+    @test u isa Uniform
+    @test mean(u) ≈ 0.5 && std(u) ≈ 0.1
+    @test dynare_prior(:uniform, 0.0, 0.0; lower=1.0, upper=3.0) == Uniform(1.0, 3.0)
+
+    # validation
+    @test_throws ArgumentError dynare_prior(:beta, 0.5, 0.6)     # std² ≥ m(1−m)
+    @test_throws ArgumentError dynare_prior(:beta, 1.2, 0.1)     # mean outside (0,1)
+    @test_throws ArgumentError dynare_prior(:gamma, -1.0, 1.0)
+    @test_throws ArgumentError dynare_prior(:uniform, 0.0, 0.0; lower=2.0, upper=1.0)
+    @test_throws ArgumentError dynare_prior(:bogus, 1.0, 1.0)
+end
+
+@testset "dynare_prior: inverse gamma on σ (InverseGamma1) (#338)" begin
+    # (mean, std) → (s, ν) inversion reproduces the requested σ-moments
+    ig = dynare_prior(:inv_gamma, 0.02, 0.05)
+    @test ig isa InverseGamma1
+    @test mean(ig) ≈ 0.02 rtol=1e-6
+    @test std(ig) ≈ 0.05 rtol=1e-6
+
+    # The density is Dynare's TYPE-1 kernel on σ (NOT σ²):
+    # log p(x₁) − log p(x₂) = −(ν+1)Δlog x − (s/2)Δ(1/x²)
+    x1, x2 = 0.03, 0.08
+    lhs = logpdf(ig, x1) - logpdf(ig, x2)
+    rhs = -(ig.nu + 1) * (log(x1) - log(x2)) - ig.s / 2 * (1 / x1^2 - 1 / x2^2)
+    @test lhs ≈ rhs rtol=1e-10
+
+    # σ² ~ InverseGamma(ν/2, s/2) — the exact Dynare correspondence
+    @test cdf(ig, 0.05) ≈ cdf(InverseGamma(ig.nu / 2, ig.s / 2), 0.05^2) rtol=1e-10
+
+    # ... and this differs from naively putting the numbers into InverseGamma
+    naive = InverseGamma(0.02, 0.05)
+    @test !(logpdf(ig, 0.05) ≈ logpdf(naive, 0.05))
+
+    # proper density: integrates to 1, quantile/cdf round trip, support
+    xs = range(1e-6, 2.0; length=200_000)
+    @test sum(pdf.(Ref(ig), xs)) * step(xs) ≈ 1.0 atol=5e-3
+    @test cdf(ig, quantile(ig, 0.3)) ≈ 0.3 rtol=1e-8
+    @test logpdf(ig, -0.1) == -Inf
+    @test minimum(ig) == 0.0 && maximum(ig) == Inf
+
+    # draw-based moments on a milder prior (ν ≈ 14.7 — 4th moment exists)
+    ig_mild = dynare_prior(:inv_gamma, 0.5, 0.1)
+    rng = Random.MersenneTwister(1)
+    draws = [rand(rng, ig_mild) for _ in 1:100_000]
+    @test mean(draws) ≈ 0.5 rtol=0.02
+    @test std(draws) ≈ 0.1 rtol=0.05
+
+    # :inv_gamma2 is on the variance with matched moments
+    igv = dynare_prior(:inv_gamma2, 0.004, 0.002)
+    @test igv isa InverseGamma
+    @test mean(igv) ≈ 0.004 rtol=1e-12
+    @test std(igv) ≈ 0.002 rtol=1e-12
+
+    # direct (s, ν) constructor validation
+    @test_throws ArgumentError InverseGamma1(-1.0, 3.0)
+    @test_throws ArgumentError InverseGamma1(1.0, -3.0)
+end
+
+@testset "dynare_prior: end-to-end in estimate_dsge_bayes (#338)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    ts = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    ts = compute_steady_state(ts)
+    data = simulate(solve(ts; method=:gensys), 200; rng=rng)'
+
+    priors = Dict{Symbol,Distribution}(
+        :ρ => dynare_prior(:beta, 0.5, 0.2),
+        :σ => dynare_prior(:inv_gamma, 0.5, 0.3))
+    fit = estimate_dsge_bayes(spec, data, [0.5, 0.5];
+        priors=priors, method=:smc, n_smc=200, observables=[:y],
+        rng=Random.MersenneTwister(3))
+    ps = posterior_summary(fit)
+    @test abs(ps[:ρ][:mean] - 0.8) < 0.25
+    @test abs(ps[:σ][:mean] - 0.5) < 0.2
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3222,4 +3222,91 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Parameter transformations for samplers (T238 / #337)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "sampler transforms: round trip + log-Jacobian (#337)" begin
+    # Positive (0,∞), interval (0,1), unbounded, shifted interval (2,5)
+    pt = ParameterTransform([0.0, 0.0, -Inf, 2.0], [1.0, Inf, Inf, 5.0])
+    theta = [0.3, 1.7, -0.4, 4.2]
+    y = to_unconstrained(pt, theta)
+    @test to_constrained(pt, y) ≈ theta rtol=1e-12
+
+    # log_jacobian equals the log-abs product of the diagonal Jacobian
+    J = transform_jacobian(pt, y)
+    @test log_jacobian(pt, y) ≈ sum(log(abs(J[i, i])) for i in 1:4) rtol=1e-10
+
+    # Finite-difference check of log|dθᵢ/dyᵢ| coordinate by coordinate
+    h = 1e-6
+    for i in 1:4
+        yp = copy(y); yp[i] += h
+        ym = copy(y); ym[i] -= h
+        d_num = (to_constrained(pt, yp)[i] - to_constrained(pt, ym)[i]) / (2h)
+        @test log(abs(J[i, i])) ≈ log(abs(d_num)) atol=1e-6
+    end
+
+    # Numerically stable at extreme y where naive σ(y)(1-σ(y)) under/overflows
+    yext = [-800.0, -800.0, -800.0, 900.0]
+    @test isfinite(log_jacobian(pt, yext))
+end
+
+@testset "RWMH transform=true: boundary-safe walk (#337)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    # σ = 0.05 sits near the zero boundary of its positive support
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.05
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.05
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 300; rng=rng)'
+    priors = Dict(:ρ => Beta(2, 2), :σ => InverseGamma(3.0, 0.2))
+
+    fit_t = estimate_dsge_bayes(spec, data, [0.5, 0.1];
+        priors=priors, method=:mh, transform=true,
+        n_draws=3000, burnin=1000, observables=[:y],
+        rng=Random.MersenneTwister(7))
+    fit_u = estimate_dsge_bayes(spec, data, [0.5, 0.1];
+        priors=priors, method=:mh, transform=false,
+        n_draws=3000, burnin=1000, observables=[:y],
+        rng=Random.MersenneTwister(7))
+
+    # Posterior means agree across parameterizations within Monte Carlo error
+    mt = vec(mean(fit_t.theta_draws; dims=1))
+    mu = vec(mean(fit_u.theta_draws; dims=1))
+    @test abs(mt[1] - mu[1]) < 0.1
+    @test abs(mt[2] - mu[2]) < 0.05
+    # ... and recover the truth (ρ = 0.8, σ = 0.05)
+    @test abs(mt[1] - 0.8) < 0.15
+    @test abs(mt[2] - 0.05) < 0.05
+    @test fit_t.acceptance_rate > 0.1
+
+    # The transformed walk never leaves the support by construction —
+    # no proposal is wasted on out-of-bounds values
+    @test all(fit_t.theta_draws[:, 2] .> 0)
+    @test all(0 .< fit_t.theta_draws[:, 1] .< 1)
+
+    # transform composes with the mode-seeded proposal (Σ mapped through D⁻¹)
+    fit_mt = estimate_dsge_bayes(spec, data, [0.5, 0.1];
+        priors=priors, method=:mh, transform=true, proposal=:mode,
+        n_draws=1500, burnin=500, observables=[:y],
+        rng=Random.MersenneTwister(9))
+    @test 0.1 < fit_mt.acceptance_rate < 0.6
+    @test abs(mean(fit_mt.theta_draws[:, 1]) - 0.8) < 0.15
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3219,6 +3219,25 @@ end
     ppc_d = posterior_predictive_check(fit; data=Matrix(data'), n_draws=50,
                                        rng=Random.MersenneTwister(5))
     @test ppc_d.observed ≈ ppc.observed
+
+    # Regression: model with MORE endogenous series than observables — the
+    # default stats must index by the observables, not by the data columns
+    spec2 = @dsge begin
+        parameters: ρ2 = 0.5, φ2 = 1.5
+        endogenous: y, i
+        exogenous: e
+        y[t] = ρ2 * y[t-1] + e[t]
+        i[t] = φ2 * y[t]
+    end
+    spec2 = compute_steady_state(spec2)
+    data2 = simulate(solve(spec2; method=:gensys), 150; rng=Random.MersenneTwister(6))
+    fit2 = estimate_dsge_bayes(spec2, data2, [0.5];
+        priors=Dict(:ρ2 => Beta(2, 2)), method=:smc, n_smc=100,
+        observables=[:y], rng=Random.MersenneTwister(13))
+    ppc2 = posterior_predictive_check(fit2; n_draws=25,
+                                      rng=Random.MersenneTwister(14))
+    @test ppc2.stat_names == ["mean_y", "var_y", "ar1_y"]   # no phantom cross-corrs
+    @test all(isfinite, ppc2.observed)
     end
 end
 

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3024,4 +3024,117 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Identification diagnostics (T236 / #335)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "identification_diagnostics: Iskrev rank test (#335)" begin
+    # Well-identified AR(1): ρ and σ identified from mean/variance/autocovariance
+    spec_ok = @dsge begin
+        parameters: ρ = 0.6, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec_ok = compute_steady_state(spec_ok)
+    idd = identification_diagnostics(spec_ok, [:ρ, :σ]; observables=[:y])
+    @test idd isa IdentificationDiagnostics{Float64}
+    @test idd.identified
+    @test idd.rank == 2
+    @test idd.n_params == 2
+    @test isempty(idd.null_space) || size(idd.null_space, 2) == 0
+    @test minimum(idd.singular_values) > idd.tol
+
+    # Deliberately unidentified: a and b enter only as the product a·b
+    spec_bad = @dsge begin
+        parameters: a = 0.5, b = 0.9, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = a * b * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec_bad = compute_steady_state(spec_bad)
+    idd2 = @test_logs (:warn, r"unidentified") match_mode=:any begin
+        identification_diagnostics(spec_bad, [:a, :b]; observables=[:y])
+    end
+    @test !idd2.identified
+    @test idd2.rank == 1
+    @test size(idd2.null_space, 2) == 1
+    # Null direction ∝ (a, -b) = (0.5, -0.9) up to sign and normalization
+    v = idd2.null_space[:, 1]
+    v = v / v[1]
+    @test v[2] ≈ -0.9 / 0.5 atol=1e-3
+
+    # show names the unidentified combination
+    io = IOBuffer()
+    show(io, idd2)
+    out = String(take!(io))
+    @test occursin("Unidentified direction", out)
+    @test occursin("NO", out)
+
+    # Input validation
+    @test_throws ArgumentError identification_diagnostics(spec_ok, Symbol[])
+    @test_throws ArgumentError identification_diagnostics(spec_ok, [:ρ]; observables=[:zzz])
+    @test_throws ArgumentError identification_diagnostics(spec_ok, [:ρ]; theta=[0.5, 0.5])
+end
+
+@testset "learning_rate_check + prior_posterior_overlap (#335)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    # κ multiplies a zero regressor → data are uninformative about κ
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5, κ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + κ * 0.0 * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5, κ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + κ * 0.0 * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 300; rng=rng)'
+
+    priors = Dict(:ρ => Beta(2, 2), :κ => Beta(2, 2))
+    fit = estimate_dsge_bayes(spec, data, [0.5, 0.5];
+        priors=priors, method=:smc, n_smc=300, observables=[:y],
+        rng=Random.MersenneTwister(11))
+
+    # Overlap: κ's posterior is essentially the prior; ρ's is not
+    ppo = prior_posterior_overlap(fit)
+    @test ppo isa PriorPosteriorOverlap{Float64}
+    ik = findfirst(==(:κ), ppo.param_names)
+    ir = findfirst(==(:ρ), ppo.param_names)
+    @test ppo.flagged[ik]
+    @test !ppo.flagged[ir]
+    @test ppo.overlap[ik] > 0.8
+    @test ppo.overlap[ir] < 0.5
+    io = IOBuffer()
+    show(io, ppo)
+    @test occursin("Overlap", String(take!(io)))
+
+    # KPS learning rate: ρ's posterior variance shrinks with T, κ's does not
+    lrc = learning_rate_check(fit; fractions=[0.4, 1.0], n_smc=200,
+                              rng=Random.MersenneTwister(3))
+    @test lrc isa LearningRateCheck{Float64}
+    @test lrc.flagged[findfirst(==(:κ), lrc.param_names)]
+    @test lrc.learning_rate[findfirst(==(:ρ), lrc.param_names)] > 0.2
+    @test size(lrc.post_vars) == (2, 2)
+    io2 = IOBuffer()
+    show(io2, lrc)
+    @test occursin("Learning-Rate", String(take!(io2)))
+
+    # Validation
+    @test_throws ArgumentError learning_rate_check(fit; fractions=[0.5])
+    @test_throws ArgumentError learning_rate_check(fit; fractions=[0.0, 1.0])
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -2929,4 +2929,99 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Bridge sampling marginal likelihood (T235 / #334)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "bridge_sampling_ml: agrees with SMC and Laplace (#334)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    sol_true = solve(true_spec; method=:gensys)
+    data = simulate(sol_true, 300; rng=rng)'
+
+    priors = Dict(:ρ => Beta(2, 2))
+
+    fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:mh, proposal=:mode,
+        n_draws=3000, burnin=1000, observables=[:y],
+        rng=Random.MersenneTwister(7))
+
+    # Estimation context is now stored on the result
+    @test !isempty(fit.data)
+    @test size(fit.data, 1) == 1                  # n_obs × T_obs orientation
+    @test fit.observables == [:y]
+    @test fit.solver == :gensys
+
+    bml = bridge_sampling_ml(fit; rng=Random.MersenneTwister(3))
+    @test isfinite(bml)
+
+    # Documented tolerance: 1 nat against the SMC tempering path and Laplace
+    smc_fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:smc, observables=[:y],
+        n_smc=300, rng=Random.MersenneTwister(11))
+    @test abs(bml - marginal_likelihood(smc_fit)) < 1.0
+
+    pm = posterior_mode(spec, data, [0.5]; priors=priors, observables=[:y])
+    @test abs(bml - pm.laplace_log_ml) < 1.0
+
+    # Student-t proposal agrees closely with the normal proposal
+    bml_t = bridge_sampling_ml(fit; proposal=:t, df=5, rng=Random.MersenneTwister(3))
+    @test isfinite(bml_t)
+    @test abs(bml_t - bml) < 0.5
+
+    # Works on SMC draws too (context stored for all methods)
+    bml_smc = bridge_sampling_ml(smc_fit; rng=Random.MersenneTwister(3))
+    @test isfinite(bml_smc)
+    @test abs(bml_smc - bml) < 0.5
+
+    # Invalid proposal family throws
+    @test_throws ArgumentError bridge_sampling_ml(fit; proposal=:bogus)
+    end
+end
+
+@testset "bridge_sampling_ml: failure paths return NaN + warn (#334)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    sol = solve(spec; method=:gensys)
+    data = simulate(sol, 100; rng=rng)'
+    priors = Dict(:ρ => Beta(2, 2))
+
+    # Chain too short → NaN + warning
+    fit_short = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:mh, n_draws=15, burnin=5, observables=[:y],
+        rng=Random.MersenneTwister(9))
+    bml = @test_logs (:warn, r"chain too short") match_mode=:any begin
+        bridge_sampling_ml(fit_short)
+    end
+    @test isnan(bml)
+    end
+end
+
 end  # @testset "Bayesian DSGE"

--- a/test/dsge/test_bayesian_dsge.jl
+++ b/test/dsge/test_bayesian_dsge.jl
@@ -3137,4 +3137,89 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Prior/posterior predictive checks (T237 / #336)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "prior_predictive + posterior_predictive_check (#336)" begin
+    _suppress_warnings() do
+    rng = Random.MersenneTwister(42)
+
+    spec = @dsge begin
+        parameters: ρ = 0.5, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    spec = compute_steady_state(spec)
+    priors = Dict(:ρ => Beta(2, 2))
+
+    # Prior predictive: draw-level statistic distribution, sensible variance
+    ppr = prior_predictive(spec, priors; n_draws=100, T_periods=150,
+                           observables=[:y], rng=Random.MersenneTwister(1))
+    @test ppr isa PriorPredictiveResult{Float64}
+    @test ppr.n_draws == 100
+    @test 0 < ppr.n_effective <= 100
+    @test size(ppr.stats) == (ppr.n_effective, length(ppr.stat_names))
+    @test "mean_y" in ppr.stat_names
+    @test "var_y" in ppr.stat_names
+    @test "ar1_y" in ppr.stat_names
+    j = findfirst(==("var_y"), ppr.stat_names)
+    @test isfinite(mean(ppr.stats[:, j]))
+    @test mean(ppr.stats[:, j]) > 0
+    io = IOBuffer()
+    show(io, ppr)
+    @test occursin("Prior Predictive", String(take!(io)))
+
+    # Posterior predictive check on a correctly specified model: interior p-values
+    true_spec = @dsge begin
+        parameters: ρ = 0.8, σ = 0.5
+        endogenous: y
+        exogenous: ε
+        y[t] = ρ * y[t-1] + σ * ε[t]
+        steady_state = [0.0]
+    end
+    true_spec = compute_steady_state(true_spec)
+    data = simulate(solve(true_spec; method=:gensys), 300; rng=rng)'
+    fit = estimate_dsge_bayes(spec, data, [0.5];
+        priors=priors, method=:smc, n_smc=200, observables=[:y],
+        rng=Random.MersenneTwister(11))
+
+    ppc = posterior_predictive_check(fit; n_draws=150, rng=Random.MersenneTwister(2))
+    @test ppc isa PosteriorPredictiveCheck{Float64}
+    @test ppc.n_effective > 0
+    @test length(ppc.p_values) == length(ppc.stat_names) == length(ppc.observed)
+    @test size(ppc.replicated) == (ppc.n_effective, length(ppc.stat_names))
+    jv = findfirst(==("var_y"), ppc.stat_names)
+    ja = findfirst(==("ar1_y"), ppc.stat_names)
+    @test 0.01 < ppc.p_values[jv] < 0.99      # model reproduces the variance
+    @test 0.01 < ppc.p_values[ja] < 0.99      # ... and the persistence
+    io2 = IOBuffer()
+    show(io2, ppc)
+    @test occursin("p-value", String(take!(io2)))
+
+    # Deliberately misspecified: prior pins ρ ≈ 0.2 while the data have ρ = 0.8
+    # → replicated persistence is far below observed → extreme p-value
+    tight = Dict(:ρ => Beta(60, 240))
+    fit_bad = estimate_dsge_bayes(spec, data, [0.2];
+        priors=tight, method=:smc, n_smc=200, observables=[:y],
+        rng=Random.MersenneTwister(12))
+    ppc_bad = posterior_predictive_check(fit_bad; n_draws=150,
+                                         rng=Random.MersenneTwister(3))
+    @test ppc_bad.p_values[findfirst(==("ar1_y"), ppc_bad.stat_names)] < 0.05
+
+    # Custom stats via NamedTuple contract
+    ppc_c = posterior_predictive_check(fit; n_draws=50, rng=Random.MersenneTwister(4),
+        stats=Y -> (skew_y = mean(((Y[:, 1] .- mean(Y[:, 1])) ./ std(Y[:, 1])).^3),))
+    @test ppc_c.stat_names == ["skew_y"]
+    @test length(ppc_c.p_values) == 1
+
+    # Explicit data argument (T_obs × n_obs orientation) matches stored data
+    ppc_d = posterior_predictive_check(fit; data=Matrix(data'), n_draws=50,
+                                       rng=Random.MersenneTwister(5))
+    @test ppc_d.observed ≈ ppc.observed
+    end
+end
+
 end  # @testset "Bayesian DSGE"


### PR DESCRIPTION
## Port stranded v0.7.0 DSGE-Bayesian features onto `dev` (#332–#338)

The v0.7.0 DSGE-Bayesian estimation features were stranded on `origin/release/v0.7.0` (forked in the v0.6.1 era); `dev` has since advanced through v0.6.2–v0.6.7, which rewrote the same DSGE-Bayes files. None of these features' symbols existed on `dev`. This branch salvages the 8 feature commits and **reconciles them with the intervening rewrites**, keeping `dev`'s later correctness fixes.

### Features

- **#332** — posterior mode finding + Laplace marginal likelihood + inverse-Hessian RWMH proposal (`proposal=:mode`)
- **#333** — MCMC convergence diagnostics: rank-normalized R̂, bulk/tail ESS, Geweke z, trace/ACF accessors
- **#334** — bridge sampling for marginal likelihood from MCMC output
- **#335** — identification diagnostics: Iskrev rank test, KPS learning-rate check, prior/posterior overlap warnings
- **#336** — prior & posterior predictive checks as first-class API
- **#337** — parameter transformations for samplers (unconstrained RWMH with log-Jacobian correction)
- **#338** — Dynare prior-convention shims (`dynare_prior` + `InverseGamma1`)

### Reconciliation

New files merge clean (`src/dsge/{identification,mcmc_diagnostics,priors}.jl`, `src/gmm/transforms.jl`). The hard conflicts were unioned across both sides: `smc.jl` (dev's burn-in proposal-freeze × v0.7.0's transform-space walk), `bayes_estimation.jl`, and `bayes_types.jl` — the `BayesianDSGE` struct now carries **20 fields** (dev's `n_failed_draws`/`n_lik_evals`/`solved_at` + v0.7.0's `data`/`observables`/`measurement_error`/`solver`/`solver_kwargs`), with both construction sites updated.

### Testing

`test_bayesian_dsge.jl` **1194/1194** and `test_dsge_hd.jl` **68/68** green locally; full suite left to CI. dev's strictness (`_orient_data` #142) and burn-in freeze (#139) are preserved as correctness.

### Issues

Resolves #332, #333, #334, #335, #336, #337, #338.

_(Targets `dev`, not the default branch — issues already closed manually with commit references. #339 (estimation on observables with trends) is a separate future item and remains open.)_
