### PR TITLE
feat(core): reproducibility manifest + versioned model serialization (#345, #347)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,12 +30,14 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 PATHSolver = "f5f7c340-0bb3-5c69-969a-41884d311d1b"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [extensions]
+MacroEconometricModelsJLD2Ext = ["JLD2"]
 MacroEconometricModelsJuMPExt = ["JuMP", "Ipopt"]
 MacroEconometricModelsPATHExt = ["JuMP", "PATHSolver"]
 MacroEconometricModelsXLSXExt = ["XLSX"]
@@ -52,6 +54,7 @@ Downloads = "1"
 FFTW = "1.5"
 ForwardDiff = "1"
 Ipopt = "1"
+JLD2 = "0.4, 0.5, 0.6"
 JuMP = "1"
 LinearAlgebra = "1"
 Logging = "1"
@@ -79,6 +82,7 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 PATHSolver = "f5f7c340-0bb3-5c69-969a-41884d311d1b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -86,4 +90,4 @@ XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [targets]
-test = ["Aqua", "Test", "Documenter", "JuMP", "Ipopt", "PATHSolver", "XLSX", "ZipFile"]
+test = ["Aqua", "Test", "Documenter", "JLD2", "JuMP", "Ipopt", "PATHSolver", "XLSX", "ZipFile"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -357,6 +357,10 @@ Publication-quality tables, display backend switching, and bibliographic referen
 | `write_csv(result, path)` | Export a result (coefficient table or `long_table`) to CSV |
 | `set_log_level(level)` | Set the global minimum log level |
 | `with_min_level(f, level)` | Run `f()` with a scoped minimum log level |
+| `capture_manifest(; seed)` | Capture a reproducibility manifest (seed, threads, versions, git) |
+| `reproduce(result)` | Re-run a randomized result from its seed; returns a `ReproReport` |
+| `save_model(model, path)` | Persist a fitted model to a versioned container (needs JLD2) |
+| `load_model(path)` | Reconstruct a saved model, validating the format version |
 | `refs(model; format=...)` | Bibliographic references |
 | `refs(io, :method; format=...)` | References by method name |
 

--- a/docs/src/api/utilities.md
+++ b/docs/src/api/utilities.md
@@ -58,6 +58,23 @@ set_log_level
 with_min_level
 ```
 
+### Reproducibility
+
+```@docs
+ReproManifest
+capture_manifest
+reproduce
+ReproReport
+```
+
+### Serialization
+
+```@docs
+save_model
+load_model
+SERIALIZATION_FORMAT_VERSION
+```
+
 ---
 
 ## Utility Functions
@@ -84,6 +101,7 @@ MacroModelError
 ConvergenceError
 IdentificationError
 SingularSystemError
+SerializationError
 ```
 
 ---

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -10,6 +10,7 @@
 - **Panel Operations**: Stata-style `xtset` for panel construction, within-group lag/lead/diff, group extraction, and balance detection
 - **Estimation Dispatch**: All estimators accept `TimeSeriesData` and `PanelData` directly --- no manual conversion required
 - **Interoperability**: `DataFrame(result)`, `long_table`, and `write_csv` turn any estimate into a tidy table or CSV for R/Python hand-off; `set_log_level` and `with_min_level` control library logging
+- **Reproducibility**: randomized results carry a `ReproManifest` (seed, threads, versions, git revision); `reproduce` re-runs and verifies bit-for-bit, and `save_model`/`load_model` persist a fitted model to a versioned container
 
 ```@setup data
 using MacroEconometricModels, DataFrames
@@ -602,6 +603,41 @@ The exposed columns are uniform across result families so downstream scripts sta
 | Forecasts (`VARForecast`, BVAR/VECM/LP) | `horizon, variable, value, lower, upper` |
 
 Bands (`lower`/`upper`) are `missing` when a result carries no uncertainty (`ci_type == :none` / `ci_method == :none`).
+
+---
+
+## Reproducibility and Model Persistence
+
+Randomized results — bootstrap IRF bands, BVAR posteriors — carry a [`ReproManifest`](@ref) that records how they were produced: the RNG seed, the thread count, the Julia and package versions, the OS, a UTC timestamp, and the package git revision. Passing a `seed` to a randomized estimator makes the draw reproducible and lets [`reproduce`](@ref) re-run the computation and confirm the numbers match bit-for-bit — the "did my published number actually come from this code" check that institutional publication workflows require.
+
+```@example data
+post = estimate_bvar(model.Y, 2; n_draws=200, seed=20260717)
+post.manifest            # seed, threads, versions, git revision
+```
+
+`reproduce` re-draws the posterior from the recorded seed and settings and reports whether it matches:
+
+```@example data
+reproduce(post)          # ReproReport: PASS (matched bit-for-bit)
+```
+
+Because a seed is not recoverable from an `AbstractRNG` after the fact, the estimator must own it: pass `seed=N` and it seeds a fresh generator, records `N`, and reproduces exactly (thread-count-invariantly). Without a `seed` the manifest still captures the environment but reports the result as not seed-reproducible. A bootstrap IRF carries a manifest too; reproduce it with `reproduce(ir, model)` (the source model is not retained on the IRF result).
+
+[`save_model`](@ref) / [`load_model`](@ref) persist a fitted model to a versioned, self-describing container backed by the optional `JLD2` package. The file records the format version, the package and Julia versions, and — for a randomized result — its reproducibility manifest, so it survives a package upgrade; a file whose `format_version` a build does not recognize is rejected with a `SerializationError` naming the expected version rather than silently mis-read.
+
+```julia
+using JLD2                                       # loads the disk backend
+save_model(post, "bvar_posterior.jld2")          # VAR/BVAR/Reg/Logit/Probit/LP supported
+post_reloaded = load_model("bvar_posterior.jld2")
+reproduce(post_reloaded)                          # still reproduces from the persisted seed
+```
+
+| Function | Description |
+|----------|-------------|
+| `capture_manifest(; seed)` | Capture the current environment as a `ReproManifest` |
+| `reproduce(result)` | Re-run from the recorded seed; returns a `ReproReport` (`matched` true/false/`missing`) |
+| `save_model(model, path)` | Persist to a versioned container (requires `using JLD2`) |
+| `load_model(path)` | Reconstruct a saved model, validating the `format_version` |
 
 ---
 

--- a/ext/MacroEconometricModelsJLD2Ext.jl
+++ b/ext/MacroEconometricModelsJLD2Ext.jl
@@ -1,0 +1,27 @@
+module MacroEconometricModelsJLD2Ext
+
+# JLD2 backend for versioned model serialization (T248 / #347).
+# Overrides the more-generic src stubs `_write_model_container` /
+# `_read_model_container`; loaded automatically when the user runs `using JLD2`.
+# The container is a plain Dict{String,Any} of primitives/arrays/nested-dicts —
+# JLD2 stores that robustly, which is the whole point of the versioned schema.
+
+using MacroEconometricModels, JLD2
+import MacroEconometricModels: _write_model_container, _read_model_container, SerializationError
+
+function _write_model_container(path::AbstractString, container)
+    JLD2.jldopen(path, "w") do f
+        f["container"] = container
+    end
+    return path
+end
+
+function _read_model_container(path::AbstractString)
+    return JLD2.jldopen(path, "r") do f
+        haskey(f, "container") || throw(SerializationError(
+            "file '$path' is not a MacroEconometricModels model file (missing 'container' group)"))
+        f["container"]
+    end
+end
+
+end # module

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -87,6 +87,9 @@ import Tables
 include("core/exceptions.jl")
 include("core/utils.jl")
 include("core/logging.jl")
+# Reproducibility manifest (#345): defines ReproManifest, a field type of
+# ImpulseResponse/BVARPosterior, so it must load before those result types.
+include("core/repro.jl")
 include("core/tolerances.jl")
 include("core/types.jl")
 include("core/display.jl")
@@ -418,6 +421,10 @@ include("summary.jl")
 # Tables.jl source interface + tidy exports (after all result types are defined)
 include("core/tables.jl")
 
+# Versioned result serialization (#347): dispatches on every result type, so it
+# loads after they are all defined (JLD2 disk backend is a weak-dep extension).
+include("core/serialization.jl")
+
 # Data conversion and estimation dispatch wrappers (after all estimation functions)
 include("data/convert.jl")
 
@@ -695,10 +702,12 @@ export contribution, total_shock_contribution, verify_decomposition
 export report, refs
 export table, print_table
 export long_table, write_csv                 # Tables.jl-compatible tidy exports (#346)
+export ReproManifest, capture_manifest, reproduce, ReproReport   # reproducibility manifest (#345)
+export save_model, load_model, SERIALIZATION_FORMAT_VERSION      # versioned serialization (#347)
 export point_estimate, has_uncertainty, uncertainty_bounds
 export set_display_backend, get_display_backend, with_display_backend
 export default_abstol, default_reltol
-export MacroModelError, ConvergenceError, IdentificationError, SingularSystemError
+export MacroModelError, ConvergenceError, IdentificationError, SingularSystemError, SerializationError
 
 # =============================================================================
 # Exports - Factor Models

--- a/src/bvar/estimation.jl
+++ b/src/bvar/estimation.jl
@@ -61,12 +61,17 @@ function estimate_bvar(Y::AbstractMatrix{T}, p::Int;
     prior::Symbol=:normal,
     hyper::Union{Nothing,MinnesotaHyperparameters}=nothing,
     varnames::Union{Vector{String},Nothing}=nothing,
+    seed::Union{Integer,Nothing}=nothing,
     rng::AbstractRNG=Random.default_rng()
 ) where {T<:AbstractFloat}
 
     _validate_data(Y, "Y")
     T_obs, n = size(Y)
     validate_var_inputs(T_obs, n, p)
+
+    # Reproducibility (T246/#345): when a `seed` is given, own the RNG so the
+    # posterior can be reproduced bit-for-bit from the recorded seed.
+    rng = _resolve_repro_rng(rng, seed)
 
     Y_eff, X = construct_var_matrices(Y, p)
     T_eff = size(Y_eff, 1)
@@ -109,15 +114,23 @@ function estimate_bvar(Y::AbstractMatrix{T}, p::Int;
 
     vn = something(varnames, ["y$i" for i in 1:n])
 
-    if sampler == :direct
-        return _sample_direct(Y, p, n, k, n_draws, B_post, V_post, ν_post, S_post, prior, vn, rng)
+    # Effective burn-in (Gibbs defaults 0 → 200); recorded in the manifest so
+    # reproduce() re-runs the exact same draw stream.
+    eff_burnin = sampler == :gibbs ? (burnin == 0 ? 200 : burnin) : burnin
+    manifest = capture_manifest(; seed=seed,
+        settings=Dict{String,Any}("burnin" => eff_burnin, "thin" => thin))
+
+    post = if sampler == :direct
+        _sample_direct(Y, p, n, k, n_draws, B_post, V_post, ν_post, S_post, prior, vn, rng)
     elseif sampler == :gibbs
-        eff_burnin = burnin == 0 ? 200 : burnin
-        return _sample_gibbs(Y, p, n, k, n_draws, eff_burnin, thin,
-                             Y_data, X_data, V0_inv, B0, ν0, S0, prior, vn, rng)
+        _sample_gibbs(Y, p, n, k, n_draws, eff_burnin, thin,
+                      Y_data, X_data, V0_inv, B0, ν0, S0, prior, vn, rng)
     else
         throw(ArgumentError("Unknown sampler: $sampler. Use :direct or :gibbs"))
     end
+
+    return BVARPosterior{T}(post.B_draws, post.Sigma_draws, post.n_draws, post.p, post.n,
+                            post.data, post.prior, post.sampler, post.varnames; manifest=manifest)
 end
 
 @float_fallback estimate_bvar Y
@@ -442,4 +455,36 @@ function forecast(post::BVARPosterior{T}, h::Int;
     end
 
     BVARForecast{T}(point, ci_lower, ci_upper, h, T(conf_level), point_estimate, post.varnames)
+end
+
+# =============================================================================
+# Reproducibility (T246 / #345)
+# =============================================================================
+
+"""
+    reproduce(post::BVARPosterior) -> ReproReport
+
+Re-draw the posterior from the manifest's recorded seed and settings and check it
+matches the stored `B_draws`/`Sigma_draws` bit-for-bit. Self-contained: the
+posterior stores its data, lag order, prior, and sampler. Requires the posterior
+to have been estimated with `estimate_bvar(Y, p; seed=N)`; without a recorded seed
+the report's `matched` is `missing`.
+
+```julia
+post = estimate_bvar(Y, 2; n_draws=500, seed=20260717)
+reproduce(post)   # ReproReport: PASS
+```
+"""
+function reproduce(post::BVARPosterior)
+    m = post.manifest
+    m === nothing && return _no_manifest_report("BVARPosterior")
+    m.seed === nothing && return _no_seed_report(m, "estimate_bvar(Y, p; seed=N)")
+    fresh = estimate_bvar(post.data, post.p;
+                          n_draws=post.n_draws, sampler=post.sampler, prior=post.prior,
+                          burnin=Int(get(m.settings, "burnin", 0)),
+                          thin=Int(get(m.settings, "thin", 1)),
+                          varnames=post.varnames, seed=m.seed)
+    diffs = [_repro_field_diff("B_draws", post.B_draws, fresh.B_draws),
+             _repro_field_diff("Sigma_draws", post.Sigma_draws, fresh.Sigma_draws)]
+    return _finalize_repro(diffs, m)
 end

--- a/src/bvar/types.jl
+++ b/src/bvar/types.jl
@@ -41,7 +41,16 @@ struct BVARPosterior{T<:AbstractFloat}
     prior::Symbol
     sampler::Symbol
     varnames::Vector{String}
+    # Reproducibility manifest (T246/#345): seed + environment used to draw this
+    # posterior; `nothing` unless `estimate_bvar` was called with `seed=`.
+    manifest::Union{ReproManifest,Nothing}
 end
+
+# Backward-compatible constructor: the 9-arg positional form defaults the manifest
+# to `nothing`, so every existing `BVARPosterior{T}(...)` call site is unchanged.
+BVARPosterior{T}(B_draws, Sigma_draws, n_draws, p, n, data, prior, sampler, varnames;
+                 manifest=nothing) where {T<:AbstractFloat} =
+    BVARPosterior{T}(B_draws, Sigma_draws, n_draws, p, n, data, prior, sampler, varnames, manifest)
 
 """
     BVARForecast{T} <: AbstractForecastResult{T}
@@ -159,4 +168,6 @@ function Base.show(io::IO, post::BVARPosterior{T}) where {T}
     _matrix_table(io, Sigma_mean, "Posterior Mean Σ";
         row_labels=vn,
         col_labels=vn)
+
+    _manifest_footer(io, post.manifest)   # reproducibility footer (T246/#345), no-op if unset
 end

--- a/src/core/exceptions.jl
+++ b/src/core/exceptions.jl
@@ -63,6 +63,19 @@ end
 SingularSystemError(msg::AbstractString; cond=nothing) =
     SingularSystemError(String(msg), cond)
 
+"""
+    SerializationError(msg) <: MacroModelError
+
+A model file cannot be read back — an unrecognized on-disk `format_version`, an
+unknown or unsupported result type, or a corrupted/missing container. Raised by
+[`load_model`](@ref); the message names the expected versus found version so an
+upgrade path is discoverable.
+"""
+struct SerializationError <: MacroModelError
+    msg::String
+end
+SerializationError(msg::AbstractString) = SerializationError(String(msg))
+
 function Base.showerror(io::IO, e::ConvergenceError)
     print(io, "ConvergenceError: ", e.msg)
     e.iters === nothing || print(io, " (iters=", e.iters, ")")
@@ -74,6 +87,8 @@ function Base.showerror(io::IO, e::SingularSystemError)
     print(io, "SingularSystemError: ", e.msg)
     e.cond === nothing || print(io, " (cond≈", e.cond, ")")
 end
+Base.showerror(io::IO, e::SerializationError) =
+    print(io, "SerializationError: ", e.msg)
 
 """
     _is_recoverable_draw_error(e) -> Bool

--- a/src/core/irf.jl
+++ b/src/core/irf.jl
@@ -45,9 +45,13 @@ function irf(model::VARModel{T}, horizon::Int;
     shock_names::Union{Nothing,Vector{String}}=nothing,
     transition_var::Union{Nothing,AbstractVector}=nothing,
     regime_indicator::Union{Nothing,AbstractVector{Int}}=nothing,
+    seed::Union{Integer,Nothing}=nothing,
     rng::AbstractRNG=Random.default_rng()
 ) where {T<:AbstractFloat}
 
+    # Reproducibility (T246/#345): a `seed` owns the RNG so bootstrap bands can be
+    # reproduced bit-for-bit (the per-replication sub-seeding is thread-invariant).
+    rng = _resolve_repro_rng(rng, seed)
     _validate_data(model.Sigma, "Sigma")
     _validate_data(model.B, "B")
     n = nvars(model)
@@ -71,8 +75,13 @@ function irf(model::VARModel{T}, horizon::Int;
 
     snames = isnothing(shock_names) ? model.varnames : shock_names
     cl = ci_type == :none ? zero(T) : T(conf_level)
+    # Attach a reproducibility manifest whenever the bands consume randomness.
+    manifest = ci_type == :none ? nothing :
+        capture_manifest(; seed=seed, settings=Dict{String,Any}(
+            "method" => String(method), "ci_type" => String(ci_type),
+            "reps" => reps, "stationary_only" => stationary_only))
     ImpulseResponse{T}(point_irf, ci_lower, ci_upper, horizon,
-                       model.varnames, snames, ci_type, sim_irfs, cl)
+                       model.varnames, snames, ci_type, sim_irfs, cl; manifest=manifest)
 end
 
 """Simulate IRFs for confidence intervals (bootstrap or asymptotic)."""
@@ -402,3 +411,44 @@ function cumulative_irf(irf_result::BayesianImpulseResponse{T}) where {T<:Abstra
                                irf_result.variables, irf_result.shocks, irf_result.quantile_levels,
                                nothing, irf_result.n_requested, irf_result.n_effective, irf_result.n_failed)
 end
+
+# =============================================================================
+# Reproducibility (T246 / #345)
+# =============================================================================
+
+"""
+    reproduce(ir::ImpulseResponse, model::VARModel) -> ReproReport
+
+Re-run the bootstrap that produced `ir`'s confidence bands from the manifest's
+recorded seed and settings and check the point IRF and bands match bit-for-bit.
+The source `model` is passed explicitly — a large object deliberately not retained
+on the IRF result. Requires `ir` to have been produced by
+`irf(model, H; ci_type=:bootstrap, seed=N)`.
+
+```julia
+model = estimate_var(Y, 2)
+ir = irf(model, 20; ci_type=:bootstrap, reps=200, seed=20260717)
+reproduce(ir, model)   # ReproReport: PASS
+```
+"""
+function reproduce(ir::ImpulseResponse, model::VARModel)
+    m = ir.manifest
+    m === nothing && return _no_manifest_report("ImpulseResponse")
+    m.seed === nothing && return _no_seed_report(m, "irf(model, H; ci_type=:bootstrap, seed=N)")
+    s = m.settings
+    fresh = irf(model, ir.horizon;
+                method = Symbol(get(s, "method", "cholesky")),
+                ci_type = Symbol(get(s, "ci_type", "bootstrap")),
+                reps = Int(get(s, "reps", ir._draws === nothing ? 0 : size(ir._draws, 1))),
+                conf_level = ir._conf_level,
+                stationary_only = Bool(get(s, "stationary_only", false)),
+                seed = m.seed)
+    diffs = [_repro_field_diff("values", ir.values, fresh.values),
+             _repro_field_diff("ci_lower", ir.ci_lower, fresh.ci_lower),
+             _repro_field_diff("ci_upper", ir.ci_upper, fresh.ci_upper)]
+    return _finalize_repro(diffs, m)
+end
+
+# Single-argument form: the source model is required (not retained on the result).
+reproduce(::ImpulseResponse) =
+    _needs_source_report("bootstrap ImpulseResponse", "reproduce(ir, model)")

--- a/src/core/repro.jl
+++ b/src/core/repro.jl
@@ -1,0 +1,356 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+# =============================================================================
+# Reproducibility manifest (T246 / #345)
+# =============================================================================
+# Records HOW a randomized result was produced — the RNG seed, thread count,
+# software versions, OS, a UTC timestamp, and the package git revision — so a
+# published IRF, posterior, or bootstrap band can later be reproduced and
+# audited. For institutional publication workflows (central banks, journals,
+# regulators) this provenance is the difference between "a number" and "a number
+# I can defend".
+#
+# The manifest is CHEAP and ALWAYS-ON: the session-constant environment (versions,
+# threads, git SHA) is captured once and memoized, so `capture_manifest` costs a
+# timestamp lookup after the first call and never slows an estimator. It NEVER
+# throws — git discovery degrades to "unknown" outside a checkout.
+#
+# A seed is NOT recoverable from an `AbstractRNG`, so bit-for-bit reproduction
+# requires the estimator to OWN the seed: pass `seed=N` to a randomized estimator
+# (`estimate_bvar`, bootstrap `irf`) and it seeds a fresh `MersenneTwister(N)`,
+# records `N` in the manifest, and `reproduce(result)` reconstructs it.
+#
+# This file is included EARLY (before the result-type definitions) because
+# `ReproManifest` is a field type of `ImpulseResponse` and `BVARPosterior`. The
+# per-type `reproduce` methods live next to their estimators (`core/irf.jl`,
+# `bvar/estimation.jl`), where both the type and the estimator are in scope.
+
+"""
+    ReproManifest
+
+Provenance record attached to a randomized result. Captures everything needed to
+argue a published number is reproducible.
+
+Fields:
+- `seed::Union{Int,Nothing}` — canonical RNG seed actually used (`nothing` when
+  the caller passed an `rng` directly rather than a `seed`, in which case the
+  computation is not bit-for-bit reproducible).
+- `n_threads::Int` — `Threads.nthreads()` at compute time (results can be
+  thread-count-dependent even at a fixed seed).
+- `julia_version::String`, `package_version::String` — the Julia and
+  MacroEconometricModels versions.
+- `dependency_versions::Dict{String,String}` — versions of key statistical
+  dependencies (Distributions, StatsAPI, …).
+- `os::String`, `machine::String` — `Sys.KERNEL` and `Sys.MACHINE`.
+- `timestamp::String` — UTC ISO-8601 capture time.
+- `git_sha::String`, `git_dirty::Bool` — the package's git commit and whether the
+  working tree had uncommitted changes (`"unknown"`/`false` outside a checkout).
+- `settings::Dict{String,Any}` — extra call parameters needed to re-run
+  (e.g. `burnin`/`thin` for a Gibbs BVAR, `reps`/`method` for a bootstrap IRF).
+
+Construct with [`capture_manifest`](@ref); reproduce with [`reproduce`](@ref).
+"""
+struct ReproManifest
+    seed::Union{Int,Nothing}
+    n_threads::Int
+    julia_version::String
+    package_version::String
+    dependency_versions::Dict{String,String}
+    os::String
+    machine::String
+    timestamp::String
+    git_sha::String
+    git_dirty::Bool
+    settings::Dict{String,Any}
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Environment capture (memoized — session-constant, so an estimator pays for it once)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_repro_verstr(m::Module) = (v = try Base.pkgversion(m) catch; nothing end;
+                            v === nothing ? "unknown" : string(v))
+
+function _repro_package_version()
+    v = try Base.pkgversion(@__MODULE__) catch; nothing end
+    return v === nothing ? "unknown" : string(v)
+end
+
+# Versions of the key statistical dependencies. All modules referenced here are
+# `using`/`import`ed at the top of the package module, so the bindings resolve.
+function _repro_dependency_versions()
+    return Dict{String,String}(
+        "Distributions" => _repro_verstr(Distributions),
+        "StatsAPI"      => _repro_verstr(StatsAPI),
+        "DataFrames"    => _repro_verstr(DataFrames),
+        "FFTW"          => _repro_verstr(FFTW),
+        "ForwardDiff"   => _repro_verstr(ForwardDiff),
+        "Optim"         => _repro_verstr(Optim),
+        "Tables"        => _repro_verstr(Tables),
+    )
+end
+
+# Package git revision + dirty flag, via `git -C <pkgdir>`. Returns
+# ("unknown", false) outside a checkout; never throws. stderr is discarded so a
+# non-git directory produces no console noise.
+function _compute_git_info()
+    dir = try pkgdir(@__MODULE__) catch; nothing end
+    (dir === nothing || !isdir(dir)) && return ("unknown", false)
+    sha = try
+        strip(read(pipeline(`git -C $dir rev-parse HEAD`; stderr=devnull), String))
+    catch
+        return ("unknown", false)
+    end
+    isempty(sha) && return ("unknown", false)
+    dirty = try
+        !isempty(strip(read(pipeline(`git -C $dir status --porcelain`; stderr=devnull), String)))
+    catch
+        false
+    end
+    return (String(sha), dirty)
+end
+
+# Session-constant environment (versions/os/git — NOT the thread count, which is a
+# runtime property). Memoized once at runtime so `capture_manifest` stays cheap.
+function _compute_static_env()
+    sha, dirty = _compute_git_info()
+    return (julia_version = string(VERSION),
+            package_version = _repro_package_version(),
+            dependency_versions = _repro_dependency_versions(),
+            os = string(Sys.KERNEL),
+            machine = string(Sys.MACHINE),
+            git_sha = sha,
+            git_dirty = dirty)
+end
+
+const _REPRO_ENV_CACHE = Ref{Any}(nothing)
+function _repro_static_env()
+    # Never memoize during precompilation — a value baked into the sysimage would
+    # freeze the build-time git/version state. Recompute (uncached) there.
+    ccall(:jl_generating_output, Cint, ()) == 1 && return _compute_static_env()
+    c = _REPRO_ENV_CACHE[]
+    c === nothing || return c
+    env = _compute_static_env()
+    _REPRO_ENV_CACHE[] = env
+    return env
+end
+
+_repro_timestamp() = try
+    Dates.format(Dates.now(Dates.UTC), dateformat"yyyy-mm-dd\THH:MM:SS\Z")
+catch
+    "unknown"
+end
+
+"""
+    capture_manifest(; seed=nothing, settings=Dict{String,Any}()) -> ReproManifest
+
+Capture a [`ReproManifest`](@ref) for the current environment. `seed` is the
+canonical RNG seed the caller used (pass the same integer given to the
+estimator's `seed=` kwarg); `settings` holds any extra call parameters needed to
+re-run. The environment portion is memoized, so this is effectively free after
+the first call and safe to invoke on every randomized estimate. Never throws.
+"""
+function capture_manifest(; seed::Union{Integer,Nothing}=nothing,
+                            settings::AbstractDict=Dict{String,Any}())
+    env = _repro_static_env()
+    return ReproManifest(
+        seed === nothing ? nothing : Int(seed),
+        Threads.nthreads(),                # runtime thread count (never cached)
+        env.julia_version,
+        env.package_version,
+        env.dependency_versions,
+        env.os,
+        env.machine,
+        _repro_timestamp(),
+        env.git_sha,
+        env.git_dirty,
+        Dict{String,Any}(settings),
+    )
+end
+
+"""
+    _resolve_repro_rng(rng, seed) -> AbstractRNG
+
+If `seed` is given, return a fresh `MersenneTwister(seed)` (so the draw stream is
+reproducible from the recorded seed); otherwise return `rng` unchanged. This is
+the single seed-injection point every randomized estimator routes through.
+"""
+_resolve_repro_rng(rng, seed::Integer) = Random.MersenneTwister(seed)
+_resolve_repro_rng(rng, ::Nothing) = rng
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Manifest ↔ Dict (plain primitives only — for versioned serialization, #347)
+# ─────────────────────────────────────────────────────────────────────────────
+
+function _manifest_to_dict(m::ReproManifest)
+    return Dict{String,Any}(
+        "__manifest__"        => true,
+        "seed"                => m.seed,
+        "n_threads"           => m.n_threads,
+        "julia_version"       => m.julia_version,
+        "package_version"     => m.package_version,
+        "dependency_versions" => Dict{String,Any}(m.dependency_versions),
+        "os"                  => m.os,
+        "machine"             => m.machine,
+        "timestamp"           => m.timestamp,
+        "git_sha"             => m.git_sha,
+        "git_dirty"           => m.git_dirty,
+        "settings"            => Dict{String,Any}(m.settings),
+    )
+end
+_manifest_to_dict(::Nothing) = nothing
+
+function _manifest_from_dict(d::AbstractDict)
+    depv = Dict{String,String}()
+    for (k, v) in get(d, "dependency_versions", Dict{String,Any}())
+        depv[String(k)] = String(v)
+    end
+    seed = get(d, "seed", nothing)
+    return ReproManifest(
+        seed === nothing ? nothing : Int(seed),
+        Int(get(d, "n_threads", 0)),
+        String(get(d, "julia_version", "unknown")),
+        String(get(d, "package_version", "unknown")),
+        depv,
+        String(get(d, "os", "unknown")),
+        String(get(d, "machine", "unknown")),
+        String(get(d, "timestamp", "unknown")),
+        String(get(d, "git_sha", "unknown")),
+        Bool(get(d, "git_dirty", false)),
+        Dict{String,Any}(get(d, "settings", Dict{String,Any}())),
+    )
+end
+_manifest_from_dict(::Nothing) = nothing
+
+# ─────────────────────────────────────────────────────────────────────────────
+# reproduce() — re-run a randomized result and compare bit-for-bit
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""Per-field comparison of an original result field against its recomputation."""
+struct ReproFieldDiff
+    name::String
+    matched::Bool
+    max_abs_diff::Float64   # NaN for non-numeric / shape-mismatched fields
+end
+
+"""
+    ReproReport
+
+Result of [`reproduce`](@ref). `matched` is `true`/`false` when a recomputation
+ran, or `missing` when reproduction could not be attempted (no manifest, no
+recorded seed, or a source object was required). `fields` holds the per-field
+comparison; `note` explains a mismatch or a thread-count caveat.
+"""
+struct ReproReport
+    matched::Union{Bool,Missing}
+    fields::Vector{ReproFieldDiff}
+    seed::Union{Int,Nothing}
+    threads_captured::Int
+    threads_current::Int
+    note::String
+end
+
+function _repro_field_diff(name::AbstractString, a, b)
+    if a isa AbstractArray && b isa AbstractArray && size(a) == size(b)
+        d = isempty(a) ? 0.0 : Float64(maximum(abs.(Float64.(a) .- Float64.(b))))
+        return ReproFieldDiff(String(name), isequal(a, b), d)
+    end
+    return ReproFieldDiff(String(name), isequal(a, b), NaN)
+end
+
+# Finalize a report from per-field diffs, attaching the thread-count caveat the
+# acceptance criteria require (mismatch under a changed thread count is flagged,
+# not silently passed).
+function _finalize_repro(diffs::Vector{ReproFieldDiff}, m::ReproManifest)
+    matched = all(d.matched for d in diffs)
+    tc = Threads.nthreads()
+    note = if !matched && tc != m.n_threads
+        "output differs AND the thread count changed ($(m.n_threads) → $tc); if this " *
+        "algorithm is thread-count-sensitive that likely explains the mismatch — re-run " *
+        "with JULIA_NUM_THREADS=$(m.n_threads)."
+    elseif !matched
+        "output differs at the same thread count ($tc); the code or a dependency version " *
+        "may have changed since capture."
+    elseif tc != m.n_threads
+        "matched despite a thread-count change ($(m.n_threads) → $tc): this computation is " *
+        "thread-count-invariant."
+    else
+        "matched bit-for-bit."
+    end
+    return ReproReport(matched, diffs, m.seed, m.n_threads, tc, note)
+end
+
+_no_manifest_report(what::AbstractString) =
+    ReproReport(missing, ReproFieldDiff[], nothing, 0, Threads.nthreads(),
+        "$what carries no reproducibility manifest; re-run the estimator with a `seed=` " *
+        "kwarg to record one.")
+
+_no_seed_report(m::ReproManifest, howto::AbstractString) =
+    ReproReport(missing, ReproFieldDiff[], nothing, m.n_threads, Threads.nthreads(),
+        "manifest has no recorded seed (an `rng` was passed instead of a `seed`); re-run " *
+        "as `$howto` to enable bit-for-bit reproduction.")
+
+_needs_source_report(what::AbstractString, howto::AbstractString) =
+    ReproReport(missing, ReproFieldDiff[], nothing, 0, Threads.nthreads(),
+        "reproducing a $what needs its source model, which is not retained on the result; " *
+        "call `$howto`.")
+
+"""
+    reproduce(result) -> ReproReport
+
+Re-run the randomized computation that produced `result` from its stored
+reproducibility manifest (same seed) and check the output matches bit-for-bit.
+This is the "did my published number actually come from this code" check.
+
+Supported: [`BVARPosterior`](@ref) (self-contained), and a bootstrap
+[`ImpulseResponse`](@ref) via the two-argument `reproduce(ir, model)` (the source
+`VARModel` is not retained on the IRF result). Returns a [`ReproReport`](@ref);
+`matched` is `missing` when reproduction cannot be attempted.
+"""
+reproduce(x) = ReproReport(missing, ReproFieldDiff[], nothing, 0, Threads.nthreads(),
+    "reproduce() is not implemented for $(typeof(x)); supported: BVARPosterior and " *
+    "bootstrap ImpulseResponse (reproduce(ir, model)).")
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Display
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""Append a one-line reproducibility footer to a result's `show`/`report`. Plain
+text (not a table) so it cannot inherit PrettyTables horizontal-crop truncation,
+mirroring `_sig_legend`. A no-op when no manifest is attached."""
+function _manifest_footer(io::IO, m::ReproManifest)
+    seedstr = m.seed === nothing ? "unset" : string(m.seed)
+    shastr = m.git_sha == "unknown" ? "unknown" :
+             first(m.git_sha, 8) * (m.git_dirty ? "+dirty" : "")
+    println(io, "Reproducibility: seed=", seedstr, ", threads=", m.n_threads,
+                ", pkg v", m.package_version, ", julia ", m.julia_version, ", git ", shastr)
+end
+_manifest_footer(::IO, ::Nothing) = nothing
+
+function Base.show(io::IO, m::ReproManifest)
+    println(io, "ReproManifest")
+    println(io, "  seed         : ", m.seed === nothing ? "unset" : m.seed)
+    println(io, "  threads      : ", m.n_threads)
+    println(io, "  julia        : ", m.julia_version)
+    println(io, "  package      : v", m.package_version)
+    println(io, "  git          : ", m.git_sha, m.git_dirty ? " (dirty)" : "")
+    println(io, "  os / machine : ", m.os, " / ", m.machine)
+    print(io,   "  captured     : ", m.timestamp)
+end
+
+function Base.show(io::IO, r::ReproReport)
+    status = r.matched === missing ? "N/A" : (r.matched ? "PASS" : "FAIL")
+    println(io, "ReproReport: ", status)
+    for d in r.fields
+        tail = isnan(d.max_abs_diff) ? "" : "  (max|Δ|=" * string(d.max_abs_diff) * ")"
+        println(io, "  ", d.matched ? "✓" : "✗", " ", d.name, tail)
+    end
+    if r.threads_captured > 0
+        println(io, "  threads: captured=", r.threads_captured, " current=", r.threads_current)
+    end
+    print(io, "  ", r.note)
+end

--- a/src/core/serialization.jl
+++ b/src/core/serialization.jl
@@ -1,0 +1,245 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+# =============================================================================
+# Versioned result serialization (T248 / #347)
+# =============================================================================
+# `save_model(result, path)` / `load_model(path)` persist a fitted model to disk
+# in a self-describing, version-tagged container so files survive a package
+# upgrade. Bare `Base.serialize` is deliberately NOT the on-disk format — it
+# breaks across Julia versions and struct-layout changes.
+#
+# Design:
+#   1. `_to_serializable(m)` reduces a result to a `Dict{String,Any}` of PLAIN
+#      values only — numbers, strings, symbols, bools, arrays, `nothing`, and
+#      nested `Dict`s. No custom structs survive into the payload (the
+#      reproducibility manifest and LP covariance estimator are themselves
+#      flattened to tagged dicts). Storing only primitives is exactly what makes
+#      the format robust across versions.
+#   2. `_build_container(m)` wraps that payload with a metadata header: the
+#      `format_version`, the package + Julia versions, a timestamp, the result
+#      type name, and (when present) the reproducibility manifest.
+#   3. The actual disk read/write is a JLD2 weak-dependency backend
+#      (`_write_model_container` / `_read_model_container`, overridden in
+#      ext/MacroEconometricModelsJLD2Ext.jl). Without JLD2 loaded the stub raises
+#      an informative "]add JLD2" error. ALL model↔dict logic and version
+#      validation stay here in src, so they are testable without the backend.
+#   4. `load_model` validates the `format_version` and type tag and raises a
+#      typed `SerializationError` naming the expected-vs-found version on a
+#      mismatch, rather than returning a corrupted object.
+
+"""
+    SERIALIZATION_FORMAT_VERSION
+
+On-disk schema version written into every model file by [`save_model`](@ref) and
+checked by [`load_model`](@ref). Bumped only on a breaking change to the payload
+layout; a file whose version this build does not recognize is rejected with a
+[`SerializationError`](@ref) rather than mis-read.
+"""
+const SERIALIZATION_FORMAT_VERSION = 1
+
+# Result types with round-trip support. Maps the stored type tag → the concrete
+# type, so `load_model` dispatches `_from_serializable` on the recorded name.
+const _SERIALIZABLE_TYPES = Dict{String,Type}(
+    "VARModel"       => VARModel,
+    "BVARPosterior"  => BVARPosterior,
+    "RegModel"       => RegModel,
+    "LogitModel"     => LogitModel,
+    "ProbitModel"    => ProbitModel,
+    "LPModel"        => LPModel,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Field-value flattening (struct → plain values) and its inverse helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Plain values pass straight through; JLD2 stores numbers/strings/symbols/bools/
+# arrays/nothing/nested-dicts robustly. Custom structs are flattened to dicts.
+_ser_field(x) = x
+_ser_field(x::ReproManifest) = _manifest_to_dict(x)
+_ser_field(x::AbstractCovarianceEstimator) = _cov_to_dict(x)
+
+_as_symbol(x::Symbol) = x
+_as_symbol(x::AbstractString) = Symbol(x)
+
+# Generic public-field capture: {fieldname => flattened value} for every field.
+function _capture_fields(m)
+    d = Dict{String,Any}()
+    for f in fieldnames(typeof(m))
+        d[String(f)] = _ser_field(getfield(m, f))
+    end
+    return d
+end
+
+_extract_manifest(m) = hasfield(typeof(m), :manifest) ? getfield(m, :manifest) : nothing
+
+# LP covariance estimator ↔ dict. These are small config structs (bandwidth,
+# kernel, prewhiten) — capture the type name + fields, rebuild by name.
+function _cov_to_dict(c::AbstractCovarianceEstimator)
+    d = Dict{String,Any}("__estimator__" => string(nameof(typeof(c))))
+    for f in fieldnames(typeof(c))
+        d[String(f)] = getfield(c, f)
+    end
+    return d
+end
+
+function _cov_from_dict(d::AbstractDict)
+    name = String(d["__estimator__"])
+    if name == "NeweyWestEstimator"
+        return NeweyWestEstimator{Float64}(Int(d["bandwidth"]), _as_symbol(d["kernel"]), Bool(d["prewhiten"]))
+    elseif name == "WhiteEstimator"
+        return WhiteEstimator()
+    elseif name == "DriscollKraayEstimator"
+        return DriscollKraayEstimator{Float64}(Int(d["bandwidth"]), _as_symbol(d["kernel"]))
+    end
+    throw(SerializationError("unknown covariance estimator '$name' in serialized LPModel"))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-type reduction and reconstruction
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Reduction is generic (public-field capture); reconstruction is explicit per
+# type so it goes through the type's real constructor (validation preserved) and
+# is forward-safe: a v1 loader knows exactly the v1 field set.
+_to_serializable(m::VARModel)      = _capture_fields(m)
+_to_serializable(m::BVARPosterior) = _capture_fields(m)
+_to_serializable(m::RegModel)      = _capture_fields(m)
+_to_serializable(m::LogitModel)    = _capture_fields(m)
+_to_serializable(m::ProbitModel)   = _capture_fields(m)
+_to_serializable(m::LPModel)       = _capture_fields(m)
+
+function _from_serializable(::Type{VARModel}, p::AbstractDict, ::Int)
+    VARModel(p["Y"], p["p"], p["B"], p["U"], p["Sigma"], p["aic"], p["bic"], p["hqic"], p["varnames"])
+end
+
+function _from_serializable(::Type{BVARPosterior}, p::AbstractDict, ::Int)
+    T = eltype(p["B_draws"])
+    mani = _manifest_from_dict(get(p, "manifest", nothing))
+    BVARPosterior{T}(p["B_draws"], p["Sigma_draws"], p["n_draws"], p["p"], p["n"],
+                     p["data"], _as_symbol(p["prior"]), _as_symbol(p["sampler"]),
+                     p["varnames"]; manifest=mani)
+end
+
+function _from_serializable(::Type{RegModel}, p::AbstractDict, ::Int)
+    T = eltype(p["y"])
+    RegModel{T}(p["y"], p["X"], p["beta"], p["vcov_mat"], p["residuals"], p["fitted"],
+                p["ssr"], p["tss"], p["r2"], p["adj_r2"], p["f_stat"], p["f_pval"],
+                p["loglik"], p["aic"], p["bic"], p["varnames"], _as_symbol(p["method"]),
+                _as_symbol(p["cov_type"]), p["weights"], p["Z"], p["endogenous"],
+                p["first_stage_f"], p["sargan_stat"], p["sargan_pval"],
+                p["cragg_donald_f"], p["kleibergen_paap_f"], p["stock_yogo_10pct"])
+end
+
+function _from_serializable(::Type{LogitModel}, p::AbstractDict, ::Int)
+    T = eltype(p["y"])
+    LogitModel{T}(p["y"], p["X"], p["beta"], p["vcov_mat"], p["residuals"], p["fitted"],
+                  p["loglik"], p["loglik_null"], p["pseudo_r2"], p["aic"], p["bic"],
+                  p["varnames"], p["converged"], p["iterations"], _as_symbol(p["cov_type"]))
+end
+
+function _from_serializable(::Type{ProbitModel}, p::AbstractDict, ::Int)
+    T = eltype(p["y"])
+    ProbitModel{T}(p["y"], p["X"], p["beta"], p["vcov_mat"], p["residuals"], p["fitted"],
+                   p["loglik"], p["loglik_null"], p["pseudo_r2"], p["aic"], p["bic"],
+                   p["varnames"], p["converged"], p["iterations"], _as_symbol(p["cov_type"]))
+end
+
+function _from_serializable(::Type{LPModel}, p::AbstractDict, ::Int)
+    cov = _cov_from_dict(p["cov_estimator"])
+    LPModel(p["Y"], p["shock_var"], p["response_vars"], p["horizon"], p["lags"],
+            p["B"], p["residuals"], p["vcov"], p["T_eff"], cov, p["varnames"])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Container assembly + validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+function _build_container(m)
+    tname = string(nameof(typeof(m)))
+    haskey(_SERIALIZABLE_TYPES, tname) || throw(SerializationError(
+        "save_model does not support $(typeof(m)); supported types: " *
+        join(sort(collect(keys(_SERIALIZABLE_TYPES))), ", ")))
+    return Dict{String,Any}(
+        "format_version"  => SERIALIZATION_FORMAT_VERSION,
+        "package_version" => _repro_package_version(),
+        "julia_version"   => string(VERSION),
+        "created"         => _repro_timestamp(),
+        "type"            => tname,
+        "manifest"        => _manifest_to_dict(_extract_manifest(m)),
+        "payload"         => _to_serializable(m),
+    )
+end
+
+function _reconstruct_from_container(container::AbstractDict)
+    ver = get(container, "format_version", nothing)
+    ver isa Integer || throw(SerializationError(
+        "not a MacroEconometricModels model file: missing or non-integer format_version"))
+    ver == SERIALIZATION_FORMAT_VERSION || throw(SerializationError(
+        "unsupported serialization format_version $ver: this build reads version " *
+        "$SERIALIZATION_FORMAT_VERSION. Re-save with the current release, or load with a " *
+        "package version whose SERIALIZATION_FORMAT_VERSION == $ver."))
+    tname = get(container, "type", nothing)
+    tname isa AbstractString || throw(SerializationError("serialized model is missing its type tag"))
+    haskey(_SERIALIZABLE_TYPES, tname) || throw(SerializationError(
+        "serialized type '$tname' is not loadable by this build; supported: " *
+        join(sort(collect(keys(_SERIALIZABLE_TYPES))), ", ")))
+    payload = get(container, "payload", nothing)
+    payload isa AbstractDict || throw(SerializationError("serialized model '$tname' has no payload"))
+    return _from_serializable(_SERIALIZABLE_TYPES[tname], payload, ver)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend stubs (overridden by the JLD2 extension) + public API
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Extension entry points — the real methods live in
+# ext/MacroEconometricModelsJLD2Ext.jl and override these more-specific-arg stubs.
+_write_model_container(path, container) =
+    error("save_model requires the JLD2 package. Run `]add JLD2` and `using JLD2` to enable it.")
+_read_model_container(path) =
+    error("load_model requires the JLD2 package. Run `]add JLD2` and `using JLD2` to enable it.")
+
+"""
+    save_model(model, path) -> path
+
+Persist a fitted `model` to `path` in a versioned, self-describing container.
+Supported: `VARModel`, `BVARPosterior`, `RegModel`, `LogitModel`, `ProbitModel`,
+`LPModel`. The file records the [`SERIALIZATION_FORMAT_VERSION`](@ref), the
+package and Julia versions, a timestamp, and — for a randomized result — its
+reproducibility manifest. Only public fields are stored; cached factorizations
+are recomputed on load rather than persisted.
+
+Requires the JLD2 backend: `]add JLD2` then `using JLD2`.
+
+```julia
+using JLD2
+m = estimate_var(Y, 2)
+save_model(m, "model.jld2")
+m2 = load_model("model.jld2")   # identical public fields
+```
+"""
+function save_model(model, path::AbstractString)
+    container = _build_container(model)
+    _write_model_container(String(path), container)
+    return path
+end
+
+"""
+    load_model(path) -> model
+
+Reconstruct a model saved by [`save_model`](@ref). Validates the stored
+`format_version` and type tag; raises a [`SerializationError`](@ref) naming the
+expected-versus-found version on an unrecognized format, rather than returning a
+corrupted object. Requires the JLD2 backend (`using JLD2`).
+"""
+function load_model(path::AbstractString)
+    isfile(path) || throw(SerializationError("no such model file: $path"))
+    container = _read_model_container(String(path))
+    container isa AbstractDict || throw(SerializationError(
+        "file '$path' does not contain a MacroEconometricModels model container"))
+    return _reconstruct_from_container(container)
+end

--- a/src/summary_display.jl
+++ b/src/summary_display.jl
@@ -264,6 +264,8 @@ function Base.show(io::IO, irf::ImpulseResponse{T}) where {T}
     if irf.ci_type != :none
         _show_note(io, "* CI excludes zero")
     end
+
+    _manifest_footer(io, irf.manifest)   # reproducibility footer (T246/#345), no-op if unset
 end
 
 function Base.show(io::IO, irf::BayesianImpulseResponse{T}) where {T}

--- a/src/var/types.jl
+++ b/src/var/types.jl
@@ -164,9 +164,20 @@ struct ImpulseResponse{T<:AbstractFloat} <: AbstractImpulseResponse
     ci_type::Symbol
     _draws::Union{Nothing, Array{T,4}}
     _conf_level::T
+    # Reproducibility manifest (T246/#345): populated by the bootstrap-IRF path,
+    # `nothing` for deterministic/analytic IRFs. Optional trailing field so every
+    # existing positional call site is unchanged.
+    manifest::Union{ReproManifest,Nothing}
 end
 
-# Backward-compatible constructors (no draws)
+# Backward-compatible constructors. The 9-arg form defaults the manifest to
+# `nothing` (covers every existing positional call site); the 7-arg form
+# additionally defaults draws/conf-level. Only the bootstrap path (core/irf.jl)
+# passes `manifest=`.
+ImpulseResponse{T}(values, ci_lower, ci_upper, horizon, variables, shocks, ci_type,
+                   _draws, _conf_level; manifest=nothing) where {T} =
+    ImpulseResponse{T}(values, ci_lower, ci_upper, horizon, variables, shocks, ci_type,
+                       _draws, _conf_level, manifest)
 ImpulseResponse{T}(values, ci_lower, ci_upper, horizon, variables, shocks, ci_type) where {T} =
     ImpulseResponse{T}(values, ci_lower, ci_upper, horizon, variables, shocks, ci_type, nothing, zero(T))
 

--- a/test/core/test_repro.jl
+++ b/test/core/test_repro.jl
@@ -1,0 +1,146 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+using MacroEconometricModels
+using Test
+using Random
+using LinearAlgebra
+
+const _MEM = MacroEconometricModels
+
+@testset "Reproducibility manifest (T246/#345)" begin
+
+    @testset "capture_manifest populates the environment and never throws" begin
+        m = capture_manifest()
+        @test m isa ReproManifest
+        @test m.seed === nothing
+        @test m.n_threads == Threads.nthreads()
+        @test m.julia_version == string(VERSION)
+        @test !isempty(m.package_version)
+        @test haskey(m.dependency_versions, "Distributions")
+        @test haskey(m.dependency_versions, "StatsAPI")
+        @test !isempty(m.timestamp)
+        @test m.git_sha isa String              # a sha or "unknown", never an error
+        @test m.git_dirty isa Bool
+        @test m.os == string(Sys.KERNEL)
+
+        m2 = capture_manifest(; seed=42, settings=Dict{String,Any}("reps" => 100))
+        @test m2.seed == 42
+        @test m2.settings["reps"] == 100
+    end
+
+    @testset "manifest ↔ dict round-trip (serialization bridge)" begin
+        m = capture_manifest(; seed=7, settings=Dict{String,Any}("burnin" => 200, "thin" => 2))
+        d = _MEM._manifest_to_dict(m)
+        @test d["__manifest__"] == true
+        m2 = _MEM._manifest_from_dict(d)
+        @test m2.seed == m.seed
+        @test m2.n_threads == m.n_threads
+        @test m2.julia_version == m.julia_version
+        @test m2.package_version == m.package_version
+        @test m2.git_sha == m.git_sha
+        @test m2.settings["burnin"] == 200
+        @test m2.dependency_versions == m.dependency_versions
+        @test _MEM._manifest_to_dict(nothing) === nothing
+        @test _MEM._manifest_from_dict(nothing) === nothing
+    end
+
+    @testset "BVAR posterior carries a manifest and reproduces bit-for-bit" begin
+        Y = randn(MersenneTwister(1), 80, 2)
+        post = estimate_bvar(Y, 2; n_draws=100, seed=20260717)
+        @test post.manifest isa ReproManifest
+        @test post.manifest.seed == 20260717
+
+        rep = reproduce(post)
+        @test rep isa ReproReport
+        @test rep.matched === true
+        @test occursin("matched", rep.note)
+
+        # same seed ⇒ identical draws; different seed ⇒ different draws
+        post_same = estimate_bvar(Y, 2; n_draws=100, seed=20260717)
+        @test post.B_draws == post_same.B_draws
+        @test post.Sigma_draws == post_same.Sigma_draws
+        post_diff = estimate_bvar(Y, 2; n_draws=100, seed=999)
+        @test post.B_draws != post_diff.B_draws
+    end
+
+    @testset "BVAR gibbs sampler reproduces (burnin/thin recorded)" begin
+        Y = randn(MersenneTwister(5), 70, 2)
+        post = estimate_bvar(Y, 2; n_draws=60, sampler=:gibbs, thin=2, seed=314)
+        @test post.manifest.settings["thin"] == 2
+        @test post.manifest.settings["burnin"] == 200   # gibbs default recorded
+        @test reproduce(post).matched === true
+    end
+
+    @testset "BVAR without a seed: manifest present, reproduction declines" begin
+        Y = randn(MersenneTwister(2), 80, 2)
+        post = estimate_bvar(Y, 2; n_draws=50)          # no seed
+        @test post.manifest isa ReproManifest
+        @test post.manifest.seed === nothing
+        rep = reproduce(post)
+        @test rep.matched === missing
+        @test occursin("no recorded seed", rep.note)
+    end
+
+    @testset "bootstrap IRF carries a manifest and reproduces via reproduce(ir, model)" begin
+        Y = randn(MersenneTwister(3), 100, 2)
+        model = estimate_var(Y, 2)
+        ir = irf(model, 10; ci_type=:bootstrap, reps=80, seed=123)
+        @test ir.manifest isa ReproManifest
+        @test ir.manifest.seed == 123
+        @test ir.manifest.settings["reps"] == 80
+        @test ir.manifest.settings["method"] == "cholesky"
+
+        rep = reproduce(ir, model)
+        @test rep.matched === true
+
+        # single-arg form asks for the source model rather than throwing
+        rep1 = reproduce(ir)
+        @test rep1.matched === missing
+        @test occursin("source model", rep1.note)
+
+        # a deterministic (no-CI) IRF has no manifest
+        ir_none = irf(model, 10)
+        @test ir_none.manifest === nothing
+    end
+
+    @testset "thread-count caveat wording in the report note" begin
+        # A fabricated manifest whose thread count differs from the current one
+        # exercises both caveat branches deterministically.
+        m = _MEM.ReproManifest(1, Threads.nthreads() + 1, "v", "p",
+                               Dict{String,String}(), "os", "mach", "ts", "sha", false,
+                               Dict{String,Any}())
+        matched = _MEM._finalize_repro([_MEM.ReproFieldDiff("x", true, 0.0)], m)
+        @test matched.matched === true
+        @test occursin("thread-count-invariant", matched.note)
+
+        mismatched = _MEM._finalize_repro([_MEM.ReproFieldDiff("x", false, 1.0)], m)
+        @test mismatched.matched === false
+        @test occursin("thread count changed", mismatched.note)
+    end
+
+    @testset "generic reproduce fallback for unsupported types" begin
+        rep = reproduce(42)
+        @test rep.matched === missing
+        @test occursin("not implemented", rep.note)
+    end
+
+    @testset "reproducibility footer appears in show output" begin
+        Y = randn(MersenneTwister(4), 80, 2)
+        post = estimate_bvar(Y, 2; n_draws=50, seed=5)
+        s = sprint(show, post)
+        @test occursin("Reproducibility:", s)
+        @test occursin("seed=5", s)
+
+        post_ns = estimate_bvar(Y, 2; n_draws=50)
+        s_ns = sprint(show, post_ns)
+        @test occursin("seed=unset", s_ns)
+
+        # ReproManifest and ReproReport render without error
+        @test occursin("ReproManifest", sprint(show, post.manifest))
+        @test occursin("ReproReport", sprint(show, reproduce(post)))
+    end
+end

--- a/test/core/test_serialization.jl
+++ b/test/core/test_serialization.jl
@@ -1,0 +1,138 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+using MacroEconometricModels
+using Test
+using JLD2                # exercises the weak-dependency disk backend
+using Random
+using LinearAlgebra
+
+const _MEM = MacroEconometricModels
+
+# Pure in-memory round-trip through the versioned container (no disk / no backend).
+_roundtrip(m) = _MEM._reconstruct_from_container(_MEM._build_container(m))
+
+@testset "Versioned serialization (T248/#347)" begin
+
+    @testset "container round-trip reconstructs public fields exactly — all types" begin
+        Y = randn(MersenneTwister(1), 120, 2)
+
+        model = estimate_var(Y, 2)
+        v2 = _roundtrip(model)
+        @test v2 isa VARModel
+        @test v2.Y == model.Y && v2.B == model.B && v2.U == model.U
+        @test v2.Sigma == model.Sigma && v2.p == model.p
+        @test v2.aic == model.aic && v2.bic == model.bic && v2.hqic == model.hqic
+        @test v2.varnames == model.varnames
+
+        post = estimate_bvar(Y, 2; n_draws=50, seed=7)
+        b2 = _roundtrip(post)
+        @test b2 isa BVARPosterior
+        @test b2.B_draws == post.B_draws && b2.Sigma_draws == post.Sigma_draws
+        @test b2.n_draws == post.n_draws && b2.data == post.data
+        @test b2.prior == post.prior && b2.sampler == post.sampler
+        @test b2.manifest isa ReproManifest && b2.manifest.seed == 7
+
+        X = hcat(ones(100), randn(MersenneTwister(2), 100, 2))
+        yv = X * [1.0, 0.5, -0.3] .+ 0.1 .* randn(MersenneTwister(3), 100)
+        reg = estimate_reg(yv, X)
+        r2 = _roundtrip(reg)
+        @test r2 isa RegModel
+        @test r2.beta == reg.beta && r2.vcov_mat == reg.vcov_mat
+        @test r2.residuals == reg.residuals && r2.r2 == reg.r2
+        @test r2.method == reg.method && r2.cov_type == reg.cov_type
+        @test r2.weights === reg.weights    # nothing survives as nothing
+
+        yb = Float64.((X * [0.0, 1.5, -1.5] .+ 0.3 .* randn(MersenneTwister(4), 100)) .> 0)
+        logit = estimate_logit(yb, X)
+        l2 = _roundtrip(logit)
+        @test l2 isa LogitModel
+        @test l2.beta == logit.beta && l2.vcov_mat == logit.vcov_mat
+        @test l2.converged == logit.converged && l2.iterations == logit.iterations
+
+        probit = estimate_probit(yb, X)
+        pr2 = _roundtrip(probit)
+        @test pr2 isa ProbitModel
+        @test pr2.beta == probit.beta && pr2.loglik == probit.loglik
+
+        lp = estimate_lp(Y, 1, 6)
+        lp2 = _roundtrip(lp)
+        @test lp2 isa LPModel
+        @test lp2.B == lp.B && lp2.residuals == lp.residuals && lp2.vcov == lp.vcov
+        @test lp2.horizon == lp.horizon && lp2.lags == lp.lags
+        @test lp2.cov_estimator isa typeof(lp.cov_estimator)
+    end
+
+    @testset "save_model / load_model disk round-trip via JLD2" begin
+        Y = randn(MersenneTwister(5), 120, 3)
+
+        model = estimate_var(Y, 2)
+        path = joinpath(mktempdir(), "var.jld2")
+        @test save_model(model, path) == path
+        @test isfile(path)
+        m2 = load_model(path)
+        @test m2 isa VARModel
+        @test m2.Y == model.Y && m2.B == model.B && m2.Sigma == model.Sigma
+        @test m2.aic == model.aic && m2.varnames == model.varnames
+
+        post = estimate_bvar(Y, 2; n_draws=40, seed=99)
+        pp = joinpath(mktempdir(), "bvar.jld2")
+        save_model(post, pp)
+        p2 = load_model(pp)
+        @test p2.B_draws == post.B_draws
+        @test p2.manifest isa ReproManifest && p2.manifest.seed == 99   # manifest persisted
+
+        # A reloaded BVAR still reproduces from its persisted seed
+        @test reproduce(p2).matched === true
+    end
+
+    @testset "container metadata header" begin
+        Y = randn(MersenneTwister(6), 80, 2)
+        c = _MEM._build_container(estimate_var(Y, 2))
+        @test c["format_version"] == SERIALIZATION_FORMAT_VERSION
+        @test c["type"] == "VARModel"
+        @test !isempty(c["package_version"])
+        @test !isempty(c["julia_version"])
+        @test haskey(c, "payload") && c["payload"] isa AbstractDict
+    end
+
+    @testset "top-level manifest travels with the container" begin
+        Y = randn(MersenneTwister(7), 80, 2)
+        post = estimate_bvar(Y, 2; n_draws=30, seed=11)
+        c = _MEM._build_container(post)
+        @test c["manifest"] isa AbstractDict
+        @test c["manifest"]["seed"] == 11
+        # a deterministic result has no manifest
+        cv = _MEM._build_container(estimate_var(Y, 2))
+        @test cv["manifest"] === nothing
+    end
+
+    @testset "unknown format_version and type raise a typed, informative error" begin
+        Y = randn(MersenneTwister(8), 80, 2)
+        c = _MEM._build_container(estimate_var(Y, 2))
+
+        bad_ver = copy(c); bad_ver["format_version"] = 999
+        err = try
+            _MEM._reconstruct_from_container(bad_ver); nothing
+        catch e
+            e
+        end
+        @test err isa SerializationError
+        @test occursin("999", err.msg)
+        @test occursin(string(SERIALIZATION_FORMAT_VERSION), err.msg)
+
+        bad_type = copy(c); bad_type["type"] = "NopeModel"
+        @test_throws SerializationError _MEM._reconstruct_from_container(bad_type)
+
+        no_ver = copy(c); delete!(no_ver, "format_version")
+        @test_throws SerializationError _MEM._reconstruct_from_container(no_ver)
+    end
+
+    @testset "unsupported save target and missing file raise SerializationError" begin
+        @test_throws SerializationError _MEM._build_container(3.14)
+        @test_throws SerializationError load_model(joinpath(mktempdir(), "does_not_exist.jld2"))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ const TEST_GROUPS = [
         "core/test_summary.jl",
         "core/test_tables.jl",
         "core/test_logging.jl",
+        "core/test_repro.jl",
+        "core/test_serialization.jl",
         "core/test_utils.jl",
         "core/test_edge_cases.jl",
         "core/test_examples.jl",
@@ -346,6 +348,8 @@ else
         @testset "Summary Tables" begin include("core/test_summary.jl") end
         @testset "Tables Interface" begin include("core/test_tables.jl") end
         @testset "Structured Logging" begin include("core/test_logging.jl") end
+        @testset "Reproducibility" begin include("core/test_repro.jl") end
+        @testset "Serialization" begin include("core/test_serialization.jl") end
         @testset "Utility Functions" begin include("core/test_utils.jl") end
         @testset "Edge Cases" begin include("core/test_edge_cases.jl") end
         @testset "Documentation Examples" begin include("core/test_examples.jl") end


### PR DESCRIPTION
Implements two tightly-coupled Tier-1 reliability features from the remediation backlog. **Stacked on #459** (`feat/tables-logging-backlog`, which lands the T247 stable field views these build on); GitHub retargets this PR to `dev` when #459 merges.

Closes #345
Closes #347

## [T246 / #345] Reproducibility manifest + `reproduce`

A `ReproManifest` records **how** a randomized result was produced — RNG seed, thread count, Julia/package/dependency versions, OS, UTC timestamp, and the package git SHA + dirty flag.

- **Cheap & always-on**: the session-constant environment is memoized (never cached at precompile — that would freeze the build-time git/version state; the thread count is read fresh each call). `capture_manifest` **never throws** — git discovery degrades to `"unknown"` outside a checkout.
- **Seed ownership**: a seed is *not* recoverable from an `AbstractRNG`, so `estimate_bvar` and the bootstrap `irf` gain a `seed` kwarg that seeds a fresh `MersenneTwister`, records it, and reproduces bit-for-bit (the per-replication sub-seeding is already thread-count-invariant).
- **Non-invasive attachment**: `ImpulseResponse` and `BVARPosterior` gain an optional trailing `manifest` field via backward-compatible convenience constructors — every existing positional call site is unchanged (verified across FAVAR/LP/DSGE/VECM construction sites).
- **`reproduce`**: `reproduce(post::BVARPosterior)` self-reproduces from stored data + seed; `reproduce(ir, model)` re-runs a bootstrap IRF. Both compare bit-for-bit and flag a thread-count caveat rather than silently passing. `show`/`report` gain a one-line reproducibility footer.

## [T248 / #347] `save_model` / `load_model`

Versioned, self-describing on-disk container so files survive a package upgrade — bare `Base.serialize` is deliberately avoided.

- Container = `format_version` + package/Julia versions + type tag + manifest + a payload of **plain values only** (numbers/strings/symbols/arrays/nested dicts — no custom structs survive, which is what makes it upgrade-robust).
- **JLD2 weak-dependency backend** (`ext/`), wired per the existing `ZipFile`/`XLSX` pattern (UUID verified `033835bb-…`). All model↔dict logic and version validation stay in `src` and are testable without the backend.
- Round-trips `VARModel` / `BVARPosterior` / `RegModel` / `LogitModel` / `ProbitModel` / `LPModel`. `load_model` rejects an unknown `format_version`/type with a typed `SerializationError` naming the expected version.

## Acceptance criteria
- [x] `load_model(save_model(m))` reconstructs VAR/BVAR/Reg/LP (and Logit/Probit) with identical public fields
- [x] Unknown `format_version` raises an informative error naming expected vs found
- [x] Saved file carries package version + (when present) the reproducibility manifest
- [x] Bootstrap IRF / BVAR posterior carry a populated `ReproManifest`; `reproduce` matches bit-for-bit at the same seed
- [x] `reproduce` reports the thread-count caveat rather than silently passing
- [x] Manifest capture degrades gracefully (git `"unknown"`) outside a checkout, never throwing
- [x] Weakdep UUID verified against the registry; `MacroEconometricModelsJLD2Ext` loads (not `nothing`)
- [x] New exports registered in `docs/src/api/utilities.md` + `api.md`; documented in `docs/src/data.md`

## Verification (relevant files only, not the full suite)
- `test/core/test_repro.jl` — **57/57**
- `test/core/test_serialization.jl` — **47/47** (includes JLD2 disk round-trip)
- Downstream (IRF/BVAR construction + show snapshots + Tables): `test_irf`, `test_irf_ci`, `test_samplers`, `test_bayesian`, `test_tables`, `test_irf_ci_bands` — **all pass**
- `Aqua.test_all` — **11/11** (validates JLD2 weakdep/compat wiring + no method ambiguities)
- `verify_examples docs/src/data.md` — **1/1 pages passed**

_Research-orchestrated implementation; full suite + docs build left to CI/deploy per project policy._