### PR TITLE
Release v0.8.2 — pin XLSX to 0.10–0.11 so Julia 1.10 CI precompiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroEconometricModels"
 uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Wookyung Chung <chung@friedman.jp>"]
 
 [deps]
@@ -75,7 +75,7 @@ StatsAPI = "1"
 TOML = "1"
 Tables = "1"
 Test = "1"
-XLSX = "0.10, 0.11, 0.12"
+XLSX = "0.10, 0.11"
 ZipFile = "0.10, 0.11"
 julia = "1.10"
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -6,6 +6,19 @@ output, not just documentation.
 
 ---
 
+## v0.8.2
+
+Patch release: restore CI on Julia 1.10. `XLSX` 0.12.2 fails to precompile against
+`XML` 0.4.5 on LTS (`XLSXError: No sheetData node found in worksheet` inside the
+XLSX precompile workload). Compat is tightened to `XLSX = "0.10, 0.11"` until an
+XLSX release loads on Julia 1.10 with the current XML 0.4 series. The Excel
+parser extension is unchanged; `using XLSX` should resolve 0.11.x.
+
+This is a patch on the `0.8` series. Downstream `[compat]` of
+`MacroEconometricModels = "0.8"` resolves here; no bound change is required.
+
+---
+
 ## v0.8.1
 
 Patch release: the **Input-Output overhaul** (`#611`) — a Baqaee--Farhi production-network

--- a/docs/src/citation.md
+++ b/docs/src/citation.md
@@ -10,7 +10,7 @@ version.
 
 Plain-text (AEA style):
 
-> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.8.1. Zenodo.
+> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.8.2. Zenodo.
 > [https://doi.org/10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170).
 
 BibTeX:
@@ -57,7 +57,7 @@ See [Utilities & Display API](@ref api_utilities) for the full `refs` signature.
 | Field | Value |
 |-------|-------|
 | Author | Wookyung Chung (`chung@friedman.jp`) |
-| Version | 0.8.1 |
+| Version | 0.8.2 |
 | Repository | [github.com/FriedmanJP/MacroEconometricModels.jl](https://github.com/FriedmanJP/MacroEconometricModels.jl) |
 | License | GPL-3.0-or-later |
 | Software DOI | [10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170) |


### PR DESCRIPTION
Patch on `dev` for [CI run 31769674554](https://github.com/FriedmanJP/MacroEconometricModels.jl/actions/runs/31769674554). Every Julia 1.10 / LTS cell failed in **Coverage-C + IO** (2 errors, 1319 passed): `using XLSX` could not precompile.

## Root cause

Not a regression in this repo. Timeline:

1. CompatHelper added `XLSX = "0.12"` on 3 Aug (`#604`).
2. Last green CI on the IO2 PR was 13 Aug 10:36 UTC.
3. [XML.jl v0.4.5](https://github.com/JuliaData/XML.jl/releases/tag/v0.4.5) registered 13 Aug 22:00 UTC.
4. `XLSX` 0.12.2 declares `XML = "0.4.4"` (i.e. `0.4.4 ≤ v < 0.5`), so CI resolved XML 0.4.5.
5. XLSX's own precompile workload (`openxlsx` on `blank.xlsx`) throws `XLSXError: No sheetData node found in worksheet` in `first_cache_fill!` (`stream.jl:396`) **on Julia 1.10 only**. The same pair precompiles on Julia 1.12.

Reproduced locally on Julia 1.10.11; XLSX 0.11.11 and XLSX 0.12.2 + XML 0.4.4 both load.

## Fix

- Tightened `[compat]` to `XLSX = "0.10, 0.11"` (the bound before CompatHelper `#604`).
- Bumped version to **v0.8.2** (`Project.toml`, `docs/src/changelog.md`, `docs/src/citation.md`). `CITATION.bib` stays versionless.

The Excel parser extension is unchanged. `using XLSX` now resolves 0.11.x, which uses XML 0.3.x and precompiles on LTS.

## Verification

- Julia 1.10.11: `XLSX` 0.12.2 + `XML` 0.4.5 → precompile **FAIL** (same `sheetData` error as CI).
- Julia 1.10.11 + this pin: resolves `XLSX` 0.11.11; `test/io/test_io_ext_parse.jl` and `test/io/test_io_source_parse.jl` **pass** (`parse_wiod xlsx` 8/8).
- `docs/verify_examples.jl` on `changelog.md` and `citation.md`: **OK** (no `@example` blocks).

This is a patch on the `0.8` series. Downstream `[compat]` of `MacroEconometricModels = "0.8"` does not need to change.

## After merge (not done here)

- [ ] Tag `v0.8.2` on `main`
- [ ] GitHub release
- [ ] `julia --project=docs docs/deploy_local.jl --version v0.8.2` (user-run only)
- [ ] `@JuliaRegistrator register`