### PR TITLE
feat(colab): precompiled depot and sysimage for Google Colab (#610)

### DIFF
--- a/.github/workflows/colab-precompiled-env.yml
+++ b/.github/workflows/colab-precompiled-env.yml
@@ -1,0 +1,107 @@
+# Colab-only precompiled depot + best-effort sysimage (#610).
+# Trigger: version tags and manual dispatch — not every PR.
+name: Colab precompiled env
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      skip_sysimage:
+        description: "Skip PackageCompiler sysimage (depot only)"
+        type: boolean
+        default: false
+      upload_to_release:
+        description: "Existing GitHub release tag to attach assets to (empty = artifacts only)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: colab-precompiled-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: linux-x86_64 Julia 1.12.6
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      JULIA_PIN: "1.12.6"
+      SKIP_SYSIMAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_sysimage && '1' || '0' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12.6"
+          arch: x64
+
+      - name: Install zstd
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zstd
+
+      - name: Build depot (and best-effort sysimage)
+        env:
+          OUT_DIR: ${{ runner.temp }}/colab-dist
+        run: |
+          chmod +x environments/colab/build_depot.sh
+          environments/colab/build_depot.sh
+          echo "OUT_DIR=${OUT_DIR}" >> "$GITHUB_ENV"
+
+      - name: Job summary
+        if: always()
+        run: |
+          if [[ -f "${OUT_DIR}/SUMMARY.md" ]]; then
+            cat "${OUT_DIR}/SUMMARY.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Build produced no SUMMARY.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload workflow artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mem-colab-${{ github.sha }}
+          path: |
+            ${{ env.OUT_DIR }}/*.tar.zst
+            ${{ env.OUT_DIR }}/*.so
+            ${{ env.OUT_DIR }}/SHA256SUMS
+            ${{ env.OUT_DIR }}/Project.toml
+            ${{ env.OUT_DIR }}/Manifest.toml
+            ${{ env.OUT_DIR }}/SUMMARY.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Attach assets to GitHub Release
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISPATCH_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_to_release || '' }}
+        run: |
+          set -euo pipefail
+          TAG=""
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          elif [[ -n "${DISPATCH_TAG}" ]]; then
+            TAG="${DISPATCH_TAG}"
+          else
+            echo "No release tag; leaving assets as workflow artifacts only."
+            exit 0
+          fi
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release create "${TAG}" --title "${TAG}" --generate-notes --verify-tag || \
+              gh release create "${TAG}" --title "${TAG}" --generate-notes
+          fi
+          shopt -s nullglob
+          files=("${OUT_DIR}"/*.tar.zst "${OUT_DIR}"/SHA256SUMS "${OUT_DIR}"/Project.toml "${OUT_DIR}"/Manifest.toml)
+          if compgen -G "${OUT_DIR}/*.so" > /dev/null; then
+            files+=("${OUT_DIR}"/*.so)
+          else
+            echo "Sysimage absent — publishing depot only." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          gh release upload "${TAG}" "${files[@]}" --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,14 @@ Key conventions to follow when contributing:
 - Always run the full test suite before submitting a PR
 - The CI pipeline runs on Ubuntu, macOS, and Windows with Julia 1.12+
 
+### Google Colab precompiled assets
+
+`environments/colab/` is a **Colab-only** parallel channel (depot tarball +
+optional sysimage), not part of a normal `Pkg.add`. Rebuilds run on version
+tags via `.github/workflows/colab-precompiled-env.yml`. See
+`environments/colab/README.md` and the release skill Colab checklist. Do not
+commit compiled depots or `.so` files.
+
 ### Running Documentation Locally
 
 ```bash

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroEconometricModels"
 uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Wookyung Chung <chung@friedman.jp>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ using Pkg
 Pkg.add("MacroEconometricModels")
 ```
 
+**Google Colab only:** new runtimes reset `~/.julia`. Releases that ship Colab assets attach a linux-x86_64 depot tarball (Julia 1.12.6 pin) so the first `estimate_var` does not cold-precompile the full dependency graph. See [`environments/colab/README.md`](environments/colab/README.md). Other platforms keep using `Pkg.add`.
+
 ## Features
 
 ### Univariate Models

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -6,6 +6,32 @@ output, not just documentation.
 
 ---
 
+## v0.8.3
+
+Patch release: optional **Google Colab precompiled assets** (`#610`) so a new
+Colab runtime does not pay a multi-minute cold precompile of
+MacroEconometricModels and its heavy dependency graph. A tag-only CI workflow
+builds a linux-x86_64 depot tarball for Colab's native Julia pin (1.12.6 as of
+the 2026.07 runtime) and attempts a PackageCompiler sysimage; the depot is the
+success criterion. In-package `PrecompileTools` and General-registry `Pkg.add`
+are unchanged. This tag also carries the genuine Bellman VFI work
+(`#615`/`#616`/`#617`) stacked under `#621`.
+
+This is a patch on the `0.8` series. Downstream `[compat]` of
+`MacroEconometricModels = "0.8"` resolves here; no bound change is required.
+
+**New**
+
+- **Colab depot** (`environments/colab/`): pinned Project/Manifest,
+  `colab_precompile.jl` workload, setup notebook, and
+  `.github/workflows/colab-precompiled-env.yml` publishing
+  `mem-colab-depot-vX.Y.Z-julia1.12.6-linux-x86_64.tar.zst` on tag or
+  `workflow_dispatch`.
+- **Bellman VFI**: `vfi_solver` is real value-function iteration (Howard
+  policy evaluation of ``V``); HA production accepts `hh_solver=:vfi`.
+
+---
+
 ## v0.8.2
 
 Patch release: restore CI on Julia 1.10. `XLSX` 0.12.2 fails to precompile against

--- a/docs/src/citation.md
+++ b/docs/src/citation.md
@@ -10,7 +10,7 @@ version.
 
 Plain-text (AEA style):
 
-> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.8.2. Zenodo.
+> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.8.3. Zenodo.
 > [https://doi.org/10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170).
 
 BibTeX:
@@ -57,7 +57,7 @@ See [Utilities & Display API](@ref api_utilities) for the full `refs` signature.
 | Field | Value |
 |-------|-------|
 | Author | Wookyung Chung (`chung@friedman.jp`) |
-| Version | 0.8.2 |
+| Version | 0.8.3 |
 | Repository | [github.com/FriedmanJP/MacroEconometricModels.jl](https://github.com/FriedmanJP/MacroEconometricModels.jl) |
 | License | GPL-3.0-or-later |
 | Software DOI | [10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170) |

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -88,6 +88,38 @@ plot_result(result)
 
 ---
 
+## [Google Colab (precompiled)](@id getting_started_colab)
+
+Colab runtimes wipe `~/.julia` on every new session, so a plain `Pkg.add` repeats a multi-minute cold precompile of Optim, NonlinearSolve, JuMP/Ipopt, and DataFrames. Releases that claim Colab assets attach a **linux-x86_64 depot tarball** (and, when PackageCompiler succeeds, a sysimage) built for Colab's native Julia pin — **1.12.6** on the 2026.07 runtime. This channel is Google Colab only. macOS, Windows, aarch64, and any other Julia patch keep using `Pkg.add` plus the in-package `PrecompileTools` workload.
+
+The depot is the supported path: interactive kernels rarely expose `--sysimage`. `DEPOT_PATH` is fixed when Julia starts, so a running Colab kernel must mutate `DEPOT_PATH` rather than set `ENV["JULIA_DEPOT_PATH"]` after launch. Full cells, Drive caching, SHA256, and the maintenance contract live in [`environments/colab/README.md`](https://github.com/FriedmanJP/MacroEconometricModels.jl/blob/dev/environments/colab/README.md); `environments/colab/colab_setup.ipynb` is the one-cell notebook.
+
+```julia
+using Downloads
+import Pkg
+const PKG_VERSION = "0.8.3"
+const JULIA_PIN = "1.12.6"
+const ASSET = "mem-colab-depot-v$(PKG_VERSION)-julia$(JULIA_PIN)-linux-x86_64.tar.zst"
+const URL = "https://github.com/FriedmanJP/MacroEconometricModels.jl/releases/download/v$(PKG_VERSION)/$(ASSET)"
+const DEST = "/content/mem-colab"
+
+if !isdir(joinpath(DEST, "depot"))
+    run(`apt-get install -y -qq zstd`)
+    Downloads.download(URL, "/tmp/$(ASSET)")
+    run(`tar -I zstd -xf /tmp/$(ASSET) -C /content`)
+end
+
+empty!(DEPOT_PATH)
+push!(DEPOT_PATH, joinpath(DEST, "depot"))
+Pkg.activate(joinpath(DEST, "env"))
+using MacroEconometricModels
+estimate_var(randn(60, 3), 2)
+```
+
+A missing sysimage on the Release is not a failure. A missing depot is: use ordinary `Pkg.add` and wait out precompile, or wait for the next tag that ships the tarball. `Pkg.update` inside the notebook voids the instant path.
+
+---
+
 ## [Where to Go Next](@id getting_started_next)
 
 - [Choosing a Method](@ref method_guide_page) — decision tables mapping a research question to the right estimator and page
@@ -97,6 +129,7 @@ plot_result(result)
 - [Innovation Accounting](@ref innovation_accounting_page) — IRF, FEVD, and historical decomposition workflows
 - [Hypothesis Tests](@ref tests_page) — unit-root, cointegration, break, and diagnostic tests
 - [Notation](@ref notation) — the symbol dictionary used throughout the documentation
+- [Google Colab (precompiled)](@ref getting_started_colab) — depot tarball for Colab's native Julia pin
 
 ---
 
@@ -128,7 +161,7 @@ Each row gives the share of one variable's ``h``-step forecast error variance at
 
 1. **Julia below 1.10.** Check with `VERSION` at the REPL. `Pkg.add` refuses to install the package on older releases, and the resolver reports an unsatisfiable `julia` compatibility bound rather than a missing package.
 
-2. **The first `using` is slow.** Precompilation runs once per package version and takes on the order of a minute. Every subsequent session loads in a few seconds. Do not interrupt the first load.
+2. **The first `using` is slow.** Precompilation runs once per package version and takes on the order of a minute. Every subsequent session loads in a few seconds. Do not interrupt the first load. On Google Colab the session depot is ephemeral — use the [precompiled depot](@ref getting_started_colab) rather than paying that cost on every runtime reset.
 
 3. **Data must be ``T \times n``.** Rows are time periods, columns are variables. A transposed matrix estimates a different model or throws a dimension error. Passing a `TimeSeriesData` removes the ambiguity entirely.
 

--- a/environments/colab/Manifest.toml
+++ b/environments/colab/Manifest.toml
@@ -1,0 +1,1638 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "bcbed45563d24227b4d83deb7e4b2b390298663a"
+
+[[deps.ADTypes]]
+git-tree-sha1 = "5970c86505ae9c07bf5bc521ef2bbbb3849e8b7b"
+uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+version = "1.23.0"
+
+    [deps.ADTypes.extensions]
+    ADTypesChainRulesCoreExt = "ChainRulesCore"
+    ADTypesConstructionBaseExt = "ConstructionBase"
+    ADTypesEnzymeCoreExt = "EnzymeCore"
+
+    [deps.ADTypes.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
+[[deps.AMD]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
+git-tree-sha1 = "45a1272e3f809d36431e57ab22703c6896b8908f"
+uuid = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
+version = "0.5.3"
+
+[[deps.ASL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6252039f98492252f9e47c312c8ffda0e3b9e78d"
+uuid = "ae81ac8f-d209-56e5-92de-9978fef736f9"
+version = "0.1.3+0"
+
+[[deps.AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.5.0"
+
+    [deps.AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
+
+    [deps.AbstractFFTs.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.7.0"
+
+    [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+    [deps.Adapt.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArrayInterface]]
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "b79a0bd275c2036b3ab9ed42ddef6f5eb48e1902"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "7.29.0"
+
+    [deps.ArrayInterface.extensions]
+    ArrayInterfaceAMDGPUExt = "AMDGPU"
+    ArrayInterfaceBandedMatricesExt = "BandedMatrices"
+    ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
+    ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceCUDSSExt = ["CUDSS", "CUDA"]
+    ArrayInterfaceChainRulesCoreExt = "ChainRulesCore"
+    ArrayInterfaceChainRulesExt = "ChainRules"
+    ArrayInterfaceFillArraysExt = "FillArrays"
+    ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceMetalExt = "Metal"
+    ArrayInterfaceReverseDiffExt = "ReverseDiff"
+    ArrayInterfaceSparseArraysExt = "SparseArrays"
+    ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
+    ArrayInterfaceTrackerExt = "Tracker"
+
+    [deps.ArrayInterface.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BracketingNonlinearSolve]]
+deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "1988c711ecd5b5d970355491a726bc355de9ba6e"
+uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+version = "1.12.5"
+
+    [deps.BracketingNonlinearSolve.extensions]
+    BracketingNonlinearSolveChainRulesCoreExt = ["ChainRulesCore", "ForwardDiff"]
+    BracketingNonlinearSolveForwardDiffExt = "ForwardDiff"
+
+    [deps.BracketingNonlinearSolve.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1b96ea4a01afe0ea4090c5c8039690672dd13f2e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.9+0"
+
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
+[[deps.CodecBzip2]]
+deps = ["Bzip2_jll", "TranscodingStreams"]
+git-tree-sha1 = "84990fa864b7f2b4901901ca12736e45ee79068c"
+uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+version = "0.8.5"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "970758a3d591a2a5c2a907c53f2e2f8c1b1d3537"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.9"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "cf963add2340ad9960e5eb22844e61ad8f931fe1"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.13"
+
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.1"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ConcreteStructs]]
+git-tree-sha1 = "804fc3ca1cbfdd5aa52ae3149c0cb0555f875eec"
+uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
+version = "0.2.7"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [deps.ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.Crayons]]
+git-tree-sha1 = "54b76cbb40d9a0f5368c880725b2f141da77c94f"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.2.0"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataFrames]]
+deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "5fab31e2e01e70ad66e3e24c968c264d1cf166d6"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "1.8.2"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "b0bc6d2cad1fed8b7fd59a1551a991cb3d2809e6"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.6"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+version = "1.9.1"
+
+[[deps.DiffResults]]
+deps = ["StaticArraysCore"]
+git-tree-sha1 = "782dd5f4561f5d267313f23853baaaa4c52ea621"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.1.0"
+
+[[deps.DiffRules]]
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "79a2aca180a85c690c58a020d47b426954b590f8"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.16.0"
+
+[[deps.DifferentiationInterface]]
+deps = ["ADTypes", "LinearAlgebra"]
+git-tree-sha1 = "dbd46a5cd0e79a97438b0ebbec42e744e8f436fe"
+uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+version = "0.7.20"
+
+    [deps.DifferentiationInterface.extensions]
+    DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
+    DifferentiationInterfaceDiffractorExt = "Diffractor"
+    DifferentiationInterfaceEnzymeExt = ["EnzymeCore", "Enzyme"]
+    DifferentiationInterfaceFastDifferentiationExt = "FastDifferentiation"
+    DifferentiationInterfaceFiniteDiffExt = "FiniteDiff"
+    DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
+    DifferentiationInterfaceForwardDiffExt = ["ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceGPUArraysCoreExt = ["GPUArraysCore", "Adapt"]
+    DifferentiationInterfaceGTPSAExt = "GTPSA"
+    DifferentiationInterfaceHyperHessiansExt = "HyperHessians"
+    DifferentiationInterfaceMooncakeExt = "Mooncake"
+    DifferentiationInterfacePolyesterForwardDiffExt = ["PolyesterForwardDiff", "ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
+    DifferentiationInterfaceSparseArraysExt = "SparseArrays"
+    DifferentiationInterfaceSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DifferentiationInterfaceSparseMatrixColoringsExt = "SparseMatrixColorings"
+    DifferentiationInterfaceStaticArraysExt = "StaticArrays"
+    DifferentiationInterfaceSymbolicsExt = "Symbolics"
+    DifferentiationInterfaceTrackerExt = "Tracker"
+    DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
+
+    [deps.DifferentiationInterface.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+    Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
+    FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+    FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
+    HyperHessians = "06b494a0-c8e0-40cc-ad32-d99506a00a6c"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.Distributions]]
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "d2facc77c08c1c2bfb1a77c148edd05b3db5410b"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.130"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.EnumX]]
+git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.7"
+
+[[deps.EnzymeCore]]
+git-tree-sha1 = "971d7831cc85f43bc9f51d615a3f7f21270c2f1d"
+uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
+version = "0.8.21"
+
+    [deps.EnzymeCore.extensions]
+    AdaptExt = "Adapt"
+    EnzymeCoreChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.EnzymeCore.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[[deps.ExprTools]]
+git-tree-sha1 = "d2e49e7efd29719d6f28b891b0e0e159daa9d2b4"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.11"
+
+[[deps.FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "Libdl", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
+git-tree-sha1 = "97f08406df914023af55ade2f843c39e99c5d969"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.10.0"
+
+[[deps.FFTW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6866aec60ef98e3164cd8d6855225684207e9dff"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.12+0"
+
+[[deps.FastClosures]]
+git-tree-sha1 = "acebe244d53ee1b461970f8910c235b259e772ef"
+uuid = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
+version = "0.3.2"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "5bad39456d9f0166184fce2248783dd9862645c1"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.17.0"
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStaticArraysExt = "StaticArrays"
+    FillArraysStatisticsExt = "Statistics"
+
+    [deps.FillArrays.weakdeps]
+    PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.FindFirstFunctions]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "bba475ce782fc77777f539cf0b7c029207798db1"
+uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
+version = "3.2.1"
+
+[[deps.FiniteDiff]]
+deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
+git-tree-sha1 = "5031f23e040bf17082e5b52422d77b5e844eefb1"
+uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
+version = "2.33.0"
+
+    [deps.FiniteDiff.extensions]
+    FiniteDiffBandedMatricesExt = "BandedMatrices"
+    FiniteDiffBlockBandedMatricesExt = "BlockBandedMatrices"
+    FiniteDiffSparseArraysExt = "SparseArrays"
+    FiniteDiffStaticArraysExt = "StaticArrays"
+
+    [deps.FiniteDiff.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "1b86cca764a61dcac4fef4c5e16e378e5ed6953c"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "1.4.5"
+
+    [deps.ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
+
+    [deps.ForwardDiff.weakdeps]
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.FunctionWrappers]]
+git-tree-sha1 = "d62485945ce5ae9c0c48f124a84998d755bae00e"
+uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
+version = "1.1.3"
+
+[[deps.FunctionWrappersWrappers]]
+deps = ["FunctionWrappers", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "daced009d54a7cf502a9b5ed2f615c341f78af6f"
+uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
+version = "1.12.1"
+
+    [deps.FunctionWrappersWrappers.extensions]
+    FunctionWrappersWrappersEnzymeExt = ["Enzyme", "EnzymeCore"]
+    FunctionWrappersWrappersMooncakeExt = "Mooncake"
+
+    [deps.FunctionWrappersWrappers.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
+
+[[deps.GPUArraysCore]]
+deps = ["Adapt"]
+git-tree-sha1 = "83cf05ab16a73219e5f6bd1bdfa9848fa24ac627"
+uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
+version = "0.2.0"
+
+[[deps.Gamma]]
+deps = ["LogExpFunctions"]
+git-tree-sha1 = "becc397f7cfb06e343496ae6ffb04818a851da51"
+uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
+version = "1.2.0"
+
+[[deps.HashArrayMappedTries]]
+git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
+uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
+version = "0.2.0"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "c35847ca5b4997fc8418836354a56c459bcf48d8"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.14.0+0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["Gamma", "LinearAlgebra"]
+git-tree-sha1 = "31bb6c92405c084617facc1d7ed9eb6c402d061e"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.30"
+
+[[deps.InlineStrings]]
+git-tree-sha1 = "8f3d257792a522b4601c24a577954b0a8cd7334d"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.4.5"
+
+    [deps.InlineStrings.extensions]
+    ArrowTypesExt = "ArrowTypes"
+    ParsersExt = "Parsers"
+
+    [deps.InlineStrings.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+    Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+
+[[deps.IntelOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "ec1debd61c300961f98064cfb21287613ad7f303"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2025.2.0+0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+weakdeps = ["Dates", "Test"]
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+[[deps.InvertedIndices]]
+git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.3.1"
+
+[[deps.Ipopt]]
+deps = ["Ipopt_jll", "LinearAlgebra", "OpenBLAS32_jll", "PrecompileTools"]
+git-tree-sha1 = "f8443766032a81e1f2cddfd4f624a5650067f0d0"
+uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+version = "1.15.0"
+weakdeps = ["MathOptInterface"]
+
+    [deps.Ipopt.extensions]
+    IpoptMathOptInterfaceExt = "MathOptInterface"
+
+[[deps.Ipopt_jll]]
+deps = ["ASL_jll", "Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "MUMPS_seq_jll", "SPRAL_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "d58bb7f6393b8ec1f6fb39eb6c1a7a83b8f8b521"
+uuid = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
+version = "300.1400.1902+0"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.7.1"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JuMP]]
+deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
+git-tree-sha1 = "614b22ff014355192982b1f9a12c61298ce6a908"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+version = "1.31.1"
+
+    [deps.JuMP.extensions]
+    JuMPDimensionalDataExt = "DimensionalData"
+
+    [deps.JuMP.weakdeps]
+    DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.Krylov]]
+deps = ["LinearAlgebra", "Printf", "SparseArrays"]
+git-tree-sha1 = "71e740d00d71cdb15145d7fe0d6000ec70534598"
+uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+version = "0.10.9"
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.4.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.LineSearch]]
+deps = ["ADTypes", "CommonSolve", "ConcreteStructs", "FastClosures", "LinearAlgebra", "MaybeInplace", "PrecompileTools", "SciMLBase", "SciMLJacobianOperators", "StaticArraysCore"]
+git-tree-sha1 = "2e05027f5a68891d997fcad60d11ce48d09208d0"
+uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
+version = "0.1.14"
+weakdeps = ["LineSearches"]
+
+    [deps.LineSearch.extensions]
+    LineSearchLineSearchesExt = "LineSearches"
+
+[[deps.LineSearches]]
+deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Printf"]
+git-tree-sha1 = "cef1ba655e8c1f65af9d96c4fffe18bf1a3a3291"
+uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+version = "7.7.1"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LinearSolve]]
+deps = ["AMD", "ArrayInterface", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "OpenBLAS_jll", "PrecompileTools", "Preferences", "PureKLU", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "Setfield", "SparseArrays", "SparseColumnPivotedQR", "StaticArraysCore"]
+git-tree-sha1 = "8ea4977471ea6e9b507e5e98d9cfcde3234f33e9"
+uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+version = "5.10.0"
+
+    [deps.LinearSolve.extensions]
+    LinearSolveAMDGPUExt = "AMDGPU"
+    LinearSolveAlgebraicMultigridExt = "AlgebraicMultigrid"
+    LinearSolveArnoldiMethodExt = "ArnoldiMethod"
+    LinearSolveArpackExt = "Arpack"
+    LinearSolveBLISExt = ["blis_jll", "LAPACK_jll"]
+    LinearSolveBandedMatricesExt = "BandedMatrices"
+    LinearSolveBlockDiagonalsExt = "BlockDiagonals"
+    LinearSolveCUDAExt = ["cuSOLVER"]
+    LinearSolveCUDSSExt = "CUDSS"
+    LinearSolveCUSOLVERRFExt = "CUSOLVERRF"
+    LinearSolveChainRulesCoreExt = "ChainRulesCore"
+    LinearSolveCliqueTreesExt = "CliqueTrees"
+    LinearSolveConjugateGradientsExt = "ConjugateGradients"
+    LinearSolveElementalExt = "Elemental"
+    LinearSolveEnzymeExt = "EnzymeCore"
+    LinearSolveFastAlmostBandedMatricesExt = "FastAlmostBandedMatrices"
+    LinearSolveFastLapackInterfaceExt = "FastLapackInterface"
+    LinearSolveForwardDiffExt = "ForwardDiff"
+    LinearSolveGinkgoExt = "Ginkgo"
+    LinearSolveHSLExt = "HSL"
+    LinearSolveHYPREExt = "HYPRE"
+    LinearSolveIterativeSolversExt = "IterativeSolvers"
+    LinearSolveJacobiDavidsonExt = "JacobiDavidson"
+    LinearSolveKernelAbstractionsExt = "KernelAbstractions"
+    LinearSolveKrylovKitExt = "KrylovKit"
+    LinearSolveMUMPSExt = "MUMPS"
+    LinearSolveMetalExt = "Metal"
+    LinearSolveMooncakeExt = "Mooncake"
+    LinearSolvePETScExt = ["PETSc", "SparseMatricesCSR"]
+    LinearSolvePETScMPIExt = ["PETSc", "PartitionedArrays", "SparseMatricesCSR"]
+    LinearSolveParUExt = "ParU_jll"
+    LinearSolvePardisoExt = "Pardiso"
+    LinearSolvePartitionedSolversExt = ["PartitionedArrays", "PartitionedSolvers"]
+    LinearSolvePureUMFPACKExt = "PureUMFPACK"
+    LinearSolveRecursiveFactorizationExt = ["RecursiveFactorization", "TriangularSolve"]
+    LinearSolveSTRUMPACKExt = "STRUMPACK_jll"
+    LinearSolveSparspakExt = "Sparspak"
+    LinearSolveSpecializingFactorizationsExt = "SpecializingFactorizations"
+    LinearSolveSuperLUDISTExt = "SuperLUDIST"
+
+    [deps.LinearSolve.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
+    ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
+    Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    CUSOLVERRF = "a8cc9031-bad2-4722-94f5-40deabb4245c"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
+    ConjugateGradients = "f59de78d-195d-4e7b-a078-2e47da4c3ad6"
+    Elemental = "902c3f28-d1ec-5e7e-8399-a24c3845ee38"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
+    FastLapackInterface = "29a986be-02c6-4525-aec4-84b980013641"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Ginkgo = "4c8bd3c9-ead9-4b5e-a625-08f1338ba0ec"
+    HSL = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
+    HYPRE = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
+    IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
+    JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
+    JacobiDavidson = "11c68b98-9c9b-11e8-267b-bbb95576cead"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
+    LAPACK_jll = "51474c39-65e3-53ba-86ba-03b1b862ec14"
+    MUMPS = "55d2b088-9f4e-11e9-26c0-150b02ea6a46"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PETSc = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
+    ParU_jll = "9e0b026c-e8ce-559c-a2c4-6a3d5c955bc9"
+    Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
+    PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
+    PartitionedSolvers = "11b65f7f-80ac-401b-9ef2-3db765482d62"
+    PureUMFPACK = "b7e1f0a2-3c4d-4e5f-9a0b-1c2d3e4f5a6b"
+    RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
+    STRUMPACK_jll = "86fbd0b9-476f-557c-b766-62c724b42d8c"
+    SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
+    Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
+    SpecializingFactorizations = "fa08b7a1-13d3-4faf-875d-5cbc1520e3f3"
+    SuperLUDIST = "4cd002a6-0da4-410d-a012-232df062f478"
+    TriangularSolve = "d5829a12-d9aa-46ab-831f-fb7c9ab06edf"
+    blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
+    cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "1.0.1"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.METIS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "2eefa8baa858871ae7770c98c3c2a7e46daba5b4"
+uuid = "d00139f3-1899-568f-a2f0-47f597d42d70"
+version = "5.1.3+0"
+
+[[deps.MKL_jll]]
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
+git-tree-sha1 = "282cadc186e7b2ae0eeadbd7a4dffed4196ae2aa"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2025.2.0+0"
+
+[[deps.MUMPS_seq_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "METIS_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "fc1daa0ab5a0d7a0a34d5168a711cbf02b2cb0cc"
+uuid = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"
+version = "500.900.100+0"
+
+[[deps.MacroEconometricModels]]
+deps = ["DataFrames", "Dates", "DelimitedFiles", "Distributions", "Downloads", "FFTW", "ForwardDiff", "Ipopt", "JuMP", "LinearAlgebra", "Logging", "NLopt", "NonlinearSolve", "Optim", "PrecompileTools", "PrettyTables", "Printf", "Random", "SHA", "ScopedValues", "SparseArrays", "SpecialFunctions", "Statistics", "StatsAPI", "TOML", "Tables"]
+path = "../.."
+uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
+version = "0.8.3"
+
+    [deps.MacroEconometricModels.extensions]
+    MacroEconometricModelsJLD2Ext = ["JLD2"]
+    MacroEconometricModelsPATHExt = ["PATHSolver"]
+    MacroEconometricModelsXLSXExt = ["XLSX"]
+    MacroEconometricModelsZipFileExt = ["ZipFile"]
+
+    [deps.MacroEconometricModels.weakdeps]
+    JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+    PATHSolver = "f5f7c340-0bb3-5c69-969a-41884d311d1b"
+    XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
+    ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MathOptInterface]]
+deps = ["CodecBzip2", "CodecZlib", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
+git-tree-sha1 = "f1ccd9ffcb8577e207deb9aaebeb3f961de70380"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "1.52.0"
+
+    [deps.MathOptInterface.extensions]
+    MathOptInterfaceBenchmarkToolsExt = "BenchmarkTools"
+    MathOptInterfaceCliqueTreesExt = "CliqueTrees"
+
+    [deps.MathOptInterface.weakdeps]
+    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+    CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
+
+[[deps.MaybeInplace]]
+deps = ["ArrayInterface", "LinearAlgebra", "MacroTools"]
+git-tree-sha1 = "69ad9ad584510f04f0ce75841253aa4b7c83e6f2"
+uuid = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
+version = "0.1.7"
+weakdeps = ["SparseArrays"]
+
+    [deps.MaybeInplace.extensions]
+    MaybeInplaceSparseArraysExt = "SparseArrays"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.MutableArithmetics]]
+deps = ["LinearAlgebra", "SparseArrays", "Test"]
+git-tree-sha1 = "dc5b2c4c111c46bc79ac4405eeb563523b39c004"
+uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+version = "1.8.0"
+
+[[deps.NLSolversBase]]
+deps = ["ADTypes", "DifferentiationInterface", "FiniteDiff", "LinearAlgebra"]
+git-tree-sha1 = "b3f76b463c7998473062992b246045e6961a074e"
+uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
+version = "8.0.0"
+
+[[deps.NLopt]]
+deps = ["CEnum", "NLopt_jll"]
+git-tree-sha1 = "624785b15005a0e0f4e462b27ee745dbe5941863"
+uuid = "76087f3c-5699-56af-9a33-bf431cd00edd"
+version = "1.2.1"
+weakdeps = ["MathOptInterface"]
+
+    [deps.NLopt.extensions]
+    NLoptMathOptInterfaceExt = ["MathOptInterface"]
+
+[[deps.NLopt_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "afe9c70ead884bf4cbb887f188d2db6d8f09d49c"
+uuid = "079eb43e-fd8e-5478-9966-2cf3e3edb778"
+version = "2.11.0+0"
+
+[[deps.NaNMath]]
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "dbd2e8cd2c1c27f0b584f6661b4309609c5a685e"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "1.1.4"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.NonlinearSolve]]
+deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "Setfield", "SimpleNonlinearSolve", "StaticArraysCore", "SymbolicIndexingInterface"]
+git-tree-sha1 = "b5cc52c89a7e2b0c5b83e887b1b2441b9c18506a"
+uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+version = "4.27.0"
+
+    [deps.NonlinearSolve.extensions]
+    NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
+    NonlinearSolveFixedPointAccelerationExt = "FixedPointAcceleration"
+    NonlinearSolveLeastSquaresOptimExt = "LeastSquaresOptim"
+    NonlinearSolveMINPACKExt = "MINPACK"
+    NonlinearSolveNLSolversExt = "NLSolvers"
+    NonlinearSolveNLsolveExt = ["NLsolve", "LineSearches"]
+    NonlinearSolvePETScExt = ["PETSc", "MPI", "SparseArrays"]
+    NonlinearSolveSIAMFANLEquationsExt = "SIAMFANLEquations"
+    NonlinearSolveSpeedMappingExt = "SpeedMapping"
+    NonlinearSolveSundialsExt = "Sundials"
+
+    [deps.NonlinearSolve.weakdeps]
+    FastLevenbergMarquardt = "7a0df574-e128-4d35-8cbd-3d84502bf7ce"
+    FixedPointAcceleration = "817d07cb-a79a-5c30-9a31-890123675176"
+    LeastSquaresOptim = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
+    LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+    MINPACK = "4854310b-de5a-5eb6-a2a5-c1dee2bd17f9"
+    MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+    NLSolvers = "337daf1e-9722-11e9-073e-8b9effe078ba"
+    NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+    PETSc = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
+    SIAMFANLEquations = "084e46ad-d928-497d-ad5e-07fa361a48c4"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"
+    Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
+
+[[deps.NonlinearSolveBase]]
+deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnumX", "EnzymeCore", "FastClosures", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "LogExpFunctions", "Markdown", "MaybeInplace", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecursiveArrayTools", "RespecializeParams", "SciMLBase", "SciMLJacobianOperators", "SciMLLogging", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
+git-tree-sha1 = "b7b455a41da55a45b0f050c119adb15da39db893"
+uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+version = "2.45.0"
+
+    [deps.NonlinearSolveBase.extensions]
+    NonlinearSolveBaseBandedMatricesExt = "BandedMatrices"
+    NonlinearSolveBaseChainRulesCoreExt = "ChainRulesCore"
+    NonlinearSolveBaseEnzymeExt = ["ChainRulesCore", "Enzyme"]
+    NonlinearSolveBaseForwardDiffExt = "ForwardDiff"
+    NonlinearSolveBaseLineSearchExt = "LineSearch"
+    NonlinearSolveBaseLinearSolveExt = "LinearSolve"
+    NonlinearSolveBaseMooncakeExt = "Mooncake"
+    NonlinearSolveBaseReverseDiffExt = "ReverseDiff"
+    NonlinearSolveBaseSparseArraysExt = "SparseArrays"
+    NonlinearSolveBaseSparseMatrixColoringsExt = "SparseMatrixColorings"
+    NonlinearSolveBaseTrackerExt = "Tracker"
+
+    [deps.NonlinearSolveBase.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    LineSearch = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
+    LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.NonlinearSolveFirstOrder]]
+deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConcreteStructs", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLJacobianOperators", "SciMLLogging", "Setfield", "StaticArraysCore"]
+git-tree-sha1 = "73b85c08fdc2ee79526405d8e67b31a9d99873d5"
+uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+version = "2.4.0"
+
+[[deps.NonlinearSolveQuasiNewton]]
+deps = ["ArrayInterface", "CommonSolve", "ConcreteStructs", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "StaticArraysCore"]
+git-tree-sha1 = "e6599aceb5fc5ca3de1978765003afc5593fe35c"
+uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+version = "1.15.1"
+weakdeps = ["ForwardDiff"]
+
+    [deps.NonlinearSolveQuasiNewton.extensions]
+    NonlinearSolveQuasiNewtonForwardDiffExt = "ForwardDiff"
+
+[[deps.NonlinearSolveSpectralMethods]]
+deps = ["CommonSolve", "ConcreteStructs", "LineSearch", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "344e673a0364838836c8f9bc9ea8da5f99e91f2b"
+uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+version = "1.8.0"
+weakdeps = ["ForwardDiff"]
+
+    [deps.NonlinearSolveSpectralMethods.extensions]
+    NonlinearSolveSpectralMethodsForwardDiffExt = "ForwardDiff"
+
+[[deps.OpenBLAS32_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "libblastrampoline_jll"]
+git-tree-sha1 = "30870d0f2dc0b2dba76b10df1c58c7f018413e56"
+uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
+version = "0.3.34+0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.Optim]]
+deps = ["ADTypes", "EnumX", "FillArrays", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "PositiveFactorizations", "Printf", "SparseArrays", "Statistics"]
+git-tree-sha1 = "6fe140aab6c042a73c9d5dc280b87b32eee44f9f"
+uuid = "429524aa-4258-5aef-a3af-852621145aeb"
+version = "2.2.1"
+weakdeps = ["MathOptInterface"]
+
+    [deps.Optim.extensions]
+    OptimMOIExt = "MathOptInterface"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.2"
+
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "123266c25174ef6c8d4718920abc206452cf8de6"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.41"
+weakdeps = ["StatsBase"]
+
+    [deps.PDMats.extensions]
+    StatsBaseExt = "StatsBase"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.7"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "36d8b4b899628fb92c2749eb488d884a926614d3"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.4.3"
+
+[[deps.PositiveFactorizations]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "17275485f373e6673f7e7f97051f703ed5b15b20"
+uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
+version = "0.2.4"
+
+[[deps.PreallocationTools]]
+deps = ["Adapt", "ArrayInterface", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "5e1c95fb1366c7f92c44839b22fc362257895a34"
+uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
+version = "1.5.0"
+
+    [deps.PreallocationTools.extensions]
+    PreallocationToolsEnzymeCoreExt = "EnzymeCore"
+    PreallocationToolsForwardDiffExt = "ForwardDiff"
+    PreallocationToolsReverseDiffExt = "ReverseDiff"
+
+    [deps.PreallocationTools.weakdeps]
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.PrettyTables]]
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "4ac881f5432bd93463a41767a814a45245be22b6"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "3.4.6"
+
+    [deps.PrettyTables.extensions]
+    PrettyTablesExcelExt = "XLSX"
+    PrettyTablesTypstryExt = "Typstry"
+
+    [deps.PrettyTables.weakdeps]
+    Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
+    XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "4fbbafbc6251b883f4d2705356f3641f3652a7fe"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.4.0"
+
+[[deps.PureKLU]]
+deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
+git-tree-sha1 = "ef341b8e734ffa12c0464a58ca1c8a214d7a4235"
+uuid = "0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
+version = "1.4.1"
+weakdeps = ["ForwardDiff"]
+
+    [deps.PureKLU.extensions]
+    PureKLUForwardDiffExt = "ForwardDiff"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.11.3"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.RecursiveArrayTools]]
+deps = ["Adapt", "ArrayInterface", "GPUArraysCore", "LinearAlgebra", "PrecompileTools", "RecipesBase", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "SymbolicIndexingInterface"]
+git-tree-sha1 = "ed53f3c9075d1317f1f6c1cf8636c88b24ab2dd6"
+uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
+version = "4.4.0"
+
+    [deps.RecursiveArrayTools.extensions]
+    RecursiveArrayToolsCUDAExt = "CUDA"
+    RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
+    RecursiveArrayToolsFastBroadcastPolyesterExt = ["FastBroadcast", "Polyester"]
+    RecursiveArrayToolsForwardDiffExt = "ForwardDiff"
+    RecursiveArrayToolsKernelAbstractionsExt = "KernelAbstractions"
+    RecursiveArrayToolsMeasurementsExt = "Measurements"
+    RecursiveArrayToolsMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    RecursiveArrayToolsMooncakeExt = "Mooncake"
+    RecursiveArrayToolsReverseDiffExt = ["ReverseDiff", "Zygote"]
+    RecursiveArrayToolsSparseArraysExt = ["SparseArrays"]
+    RecursiveArrayToolsStatisticsExt = "Statistics"
+    RecursiveArrayToolsStructArraysExt = "StructArrays"
+    RecursiveArrayToolsTablesExt = ["Tables"]
+    RecursiveArrayToolsTrackerExt = "Tracker"
+    RecursiveArrayToolsZygoteExt = "Zygote"
+
+    [deps.RecursiveArrayTools.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.RespecializeParams]]
+deps = ["FunctionWrappersWrappers"]
+git-tree-sha1 = "a6b8358681ac20a448dc762770487e25c98a5085"
+uuid = "9fe22ead-9e00-4db2-8b46-706a60d40f5e"
+version = "1.2.0"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "5b3d50eb374cea306873b371d3f8d3915a018f0b"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.9.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6d40b2fe70437b01397d2a4d5b020008da4e7019"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.2+0"
+
+[[deps.Roots]]
+deps = ["Accessors", "CommonSolve", "Printf"]
+git-tree-sha1 = "7fb25a964849d90a0446366cdefca822e0e84900"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "3.0.6"
+
+    [deps.Roots.extensions]
+    RootsChainRulesCoreExt = "ChainRulesCore"
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+    RootsUnitfulExt = "Unitful"
+
+    [deps.Roots.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.RuntimeGeneratedFunctions]]
+deps = ["ExprTools", "SHA", "Serialization"]
+git-tree-sha1 = "65c9e1142f0372bfc16ba14b9edd57737fe0039f"
+uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+version = "0.5.24"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SPRAL_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "Libdl", "METIS_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "139fa63f03a16b3d859d925ee9149dfc15f21ece"
+uuid = "319450e9-13b8-58e8-aa9f-8fd1420848ab"
+version = "2025.9.18+0"
+
+[[deps.SciMLBase]]
+deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FindFirstFunctions", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "LoggingExtras", "Markdown", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "Random", "RecipesBase", "RecursiveArrayTools", "RuntimeGeneratedFunctions", "SciMLLogging", "SciMLOperators", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
+git-tree-sha1 = "8588951d53350cb52df294ea41295b654e6ea0ab"
+uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+version = "3.47.1"
+
+    [deps.SciMLBase.extensions]
+    SciMLBaseChainRulesCoreExt = "ChainRulesCore"
+    SciMLBaseDifferentiationInterfaceExt = "DifferentiationInterface"
+    SciMLBaseDistributionsExt = "Distributions"
+    SciMLBaseEnzymeExt = "Enzyme"
+    SciMLBaseForwardDiffExt = "ForwardDiff"
+    SciMLBaseFunctionPropertiesExt = "FunctionProperties"
+    SciMLBaseMakieExt = ["Makie", "GeometryBasics"]
+    SciMLBaseMeasurementsExt = "Measurements"
+    SciMLBaseMonteCarloMeasurementsExt = "MonteCarloMeasurements"
+    SciMLBaseMooncakeExt = "Mooncake"
+    SciMLBasePartialFunctionsExt = "PartialFunctions"
+    SciMLBasePyCallExt = "PyCall"
+    SciMLBasePythonCallExt = "PythonCall"
+    SciMLBaseRCallExt = "RCall"
+    SciMLBaseReverseDiffExt = ["ReverseDiff", "ForwardDiff"]
+    SciMLBaseStaticArraysExt = "StaticArrays"
+    SciMLBaseTrackerExt = "Tracker"
+    SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore", "ZygoteRules", "FillArrays"]
+
+    [deps.SciMLBase.weakdeps]
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+    Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    FunctionProperties = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
+    GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PartialFunctions = "570af359-4316-4cb7-8c74-252c00c2016b"
+    PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+    PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+    RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+    ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
+
+[[deps.SciMLJacobianOperators]]
+deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DifferentiationInterface", "FastClosures", "LinearAlgebra", "SciMLBase", "SciMLOperators"]
+git-tree-sha1 = "ad167d716fc134c0873c76ba0469ede56a678732"
+uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
+version = "0.1.17"
+
+[[deps.SciMLLogging]]
+deps = ["Logging", "LoggingExtras", "Preferences"]
+git-tree-sha1 = "36be2198d9dc476ac27efb1fe0f789d9e1dca01c"
+uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
+version = "2.0.4"
+
+    [deps.SciMLLogging.extensions]
+    SciMLLoggingTracyExt = "Tracy"
+
+    [deps.SciMLLogging.weakdeps]
+    Tracy = "e689c965-62c8-4b79-b2c5-8359227902fd"
+
+[[deps.SciMLOperators]]
+deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "SciMLPublic"]
+git-tree-sha1 = "144473d0a737d9c1e1bf2dc5ea824dc1be864f33"
+uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+version = "1.27.0"
+
+    [deps.SciMLOperators.extensions]
+    SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
+    SciMLOperatorsSparseArraysExt = "SparseArrays"
+
+    [deps.SciMLOperators.weakdeps]
+    LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.SciMLPublic]]
+git-tree-sha1 = "cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79"
+uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
+version = "1.2.4"
+
+[[deps.SciMLStructures]]
+deps = ["ArrayInterface", "PrecompileTools"]
+git-tree-sha1 = "53bf620cb2c3763d41495b2a145611c6ca400dcd"
+uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
+version = "1.10.4"
+
+[[deps.ScopedValues]]
+deps = ["HashArrayMappedTries", "Logging"]
+git-tree-sha1 = "67a144433c4ce877ee6d1ada69a124d6b1ecf7be"
+uuid = "7e506255-f358-4e82-b7e4-beb19740aa63"
+version = "1.6.2"
+
+[[deps.SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "084c47c7c5ce5cfecefa0a98dff69eb3646b5a80"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.4.10"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "c5391c6ace3bc430ca630251d02ea9687169ca68"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.2"
+
+[[deps.SimpleNonlinearSolve]]
+deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging", "Setfield", "StaticArraysCore"]
+git-tree-sha1 = "bb811cd81991c786a590cc9d00a7add142f5a8b7"
+uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
+version = "2.14.0"
+
+    [deps.SimpleNonlinearSolve.extensions]
+    SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
+    SimpleNonlinearSolveReverseDiffExt = "ReverseDiff"
+    SimpleNonlinearSolveTrackerExt = "Tracker"
+
+    [deps.SimpleNonlinearSolve.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "13cd91cc9be159e3f4d95b857fa2aa383b53772a"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.3"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.SparseColumnPivotedQR]]
+deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
+git-tree-sha1 = "ee8155fd93f0efc510e4523850bd9e0bb6e03199"
+uuid = "a57abbd0-fea5-4d57-96be-5e525945e8e4"
+version = "2.1.6"
+weakdeps = ["AMD"]
+
+    [deps.SparseColumnPivotedQR.extensions]
+    SparseColumnPivotedQRAMDExt = "AMD"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "c3ac026e735264e9bdc6a9bcbd1b1e781b36e3bc"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.3"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "178ed29fd5b2a2cfc3bd31c13375ae925623ff36"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.8.0"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.12"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "91a5737baed20ee31f3faea0e51f57461f6a689e"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "2.2.1"
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.StringManipulation]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "8a90c1d77c3277a5d43b83927b3cbe2c70a37484"
+uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
+version = "0.4.7"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.5"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.SymbolicIndexingInterface]]
+deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
+git-tree-sha1 = "2167b9913f3013a1485bdc9bb249123eb8b53cb0"
+uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
+version = "0.3.54"
+weakdeps = ["PrettyTables"]
+
+    [deps.SymbolicIndexingInterface.extensions]
+    SymbolicIndexingInterfacePrettyTablesExt = "PrettyTables"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.13.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TimerOutputs]]
+deps = ["ExprTools", "PrettyTables", "Printf", "Tables"]
+git-tree-sha1 = "e9b4907b22ce6f51ab0effc321a56dac24614b70"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "1.2.0"
+
+    [deps.TimerOutputs.extensions]
+    FlameGraphsExt = "FlameGraphs"
+
+    [deps.TimerOutputs.weakdeps]
+    FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "80d3930c6347cfce7ccf96bd3bafdf079d9c0390"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.13.9+0"
+
+[[deps.Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "58972370b81423fc546c56a60ed1a009450177c3"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.19.0+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.oneTBB_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "da8c1f6eee04831f14edcfa5dae611d309807e57"
+uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
+version = "2022.3.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/environments/colab/Project.toml
+++ b/environments/colab/Project.toml
@@ -1,0 +1,10 @@
+# Google Colab only (#610). Not the General-registry package tarball.
+# Pin: Julia 1.12.6 (Colab 2026.07 runtime) × linux-x86_64.
+
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+MacroEconometricModels = "14a6ec33-bcac-448e-845f-2fb6769698f1"
+
+[compat]
+DataFrames = "1"
+julia = "1.12"

--- a/environments/colab/README.md
+++ b/environments/colab/README.md
@@ -1,0 +1,180 @@
+# Google Colab (precompiled)
+
+**Google Colab only.** This directory is a parallel channel for Colab notebook
+users. It is not a replacement for a normal `Pkg.add("MacroEconometricModels")`
+install, and it does not change General-registry package behaviour. In-package
+`PrecompileTools` (`src/precompile.jl`) still pays first-call latency for every
+other platform.
+
+Colab runtimes reset `~/.julia` on every new session. The product here is a
+**prebuilt Linux x86_64 depot** (primary) and an optional **PackageCompiler
+sysimage** (secondary) attached to the GitHub Release, so the first
+`estimate_var` does not wait through a multi-minute cold precompile of
+Optim / NonlinearSolve / JuMP / Ipopt / DataFrames.
+
+## Pin
+
+| Field | Value |
+|---|---|
+| Julia | **1.12.6** (Colab 2026.07 native runtime) |
+| OS / arch | **linux-x86_64** only |
+| Package | version on the matching GitHub Release tag (`vX.Y.Z`) |
+
+Wrong Julia patch, macOS, Windows, or aarch64: use ordinary `Pkg.add` and let
+`PrecompileTools` run. Do not expand this matrix unless Colab itself requires it.
+
+Confirm the live Colab pin before advertising a new release:
+
+```julia
+VERSION   # must print 1.12.6
+```
+
+If Colab has moved, bump `JULIA_PIN` in `build_depot.sh` and
+`.github/workflows/colab-precompiled-env.yml`, refresh `Manifest.toml`, and
+rebuild.
+
+## Release assets
+
+On tag `vX.Y.Z` (and on `workflow_dispatch`):
+
+| Asset | Role |
+|---|---|
+| `mem-colab-depot-vX.Y.Z-julia1.12.6-linux-x86_64.tar.zst` | Isolated depot + `env/Project.toml` + `env/Manifest.toml` |
+| `MacroEM-colab-vX.Y.Z-julia1.12.6-linux-x86_64.so` | Best-effort sysimage; **absent is OK** |
+| `SHA256SUMS`, `Project.toml`, `Manifest.toml` | Checksums and the env files also nested in the tarball |
+
+Tarball layout after extract:
+
+```text
+mem-colab/
+  depot/     # JULIA_DEPOT_PATH / DEPOT_PATH entry
+  env/       # activate this project
+```
+
+These binaries are **not** inside the General-registry package tarball.
+
+## Setup on Colab (depot, primary)
+
+`DEPOT_PATH` is fixed at Julia startup. Setting `ENV["JULIA_DEPOT_PATH"]` in an
+already-running kernel is too late — mutate `DEPOT_PATH` instead. A native
+Colab Julia kernel should run this **before** any `using Pkg` / package load.
+
+```julia
+# 1. Fetch the depot for this package version + Julia pin.
+using Downloads
+import Pkg
+const PKG_VERSION = "0.8.3"
+const JULIA_PIN = "1.12.6"
+const ASSET = "mem-colab-depot-v$(PKG_VERSION)-julia$(JULIA_PIN)-linux-x86_64.tar.zst"
+const URL = "https://github.com/FriedmanJP/MacroEconometricModels.jl/releases/download/v$(PKG_VERSION)/$(ASSET)"
+const DEST = "/content/mem-colab"
+const TARBALL = "/tmp/$(ASSET)"
+
+if !isdir(joinpath(DEST, "depot"))
+    run(`apt-get install -y -qq zstd`)
+    Downloads.download(URL, TARBALL)
+    mkpath("/content")
+    run(`tar -I zstd -xf $(TARBALL) -C /content`)
+end
+
+# 2. Point this session at the extracted depot, then activate the shipped env.
+empty!(DEPOT_PATH)
+push!(DEPOT_PATH, joinpath(DEST, "depot"))
+Pkg.activate(joinpath(DEST, "env"))
+
+# 3. Smoke.
+using MacroEconometricModels
+@time estimate_var(randn(60, 3), 2)
+```
+
+A notebook that already contains this cell lives at
+[`colab_setup.ipynb`](colab_setup.ipynb).
+
+### Optional: Google Drive cache (session 2+)
+
+After the first successful extract:
+
+```julia
+# Mount Drive from a Colab Python cell first:
+#   from google.colab import drive
+#   drive.mount("/content/drive")
+const DRIVE = "/content/drive/MyDrive/mem-colab"
+if isdir("/content/drive/MyDrive") && !isdir(DRIVE)
+    cp("/content/mem-colab", DRIVE; force=true)
+end
+```
+
+On the next runtime, copy `DRIVE` back to `/content/mem-colab` instead of
+re-downloading the release asset.
+
+### Optional: sysimage (bash / self-installed Julia)
+
+Interactive Colab kernels rarely expose `--sysimage`. Use the `.so` only from a
+`%%bash` cell or a Julia you installed yourself, with the **same** 1.12.6 pin:
+
+```bash
+julia --sysimage=MacroEM-colab-v0.8.3-julia1.12.6-linux-x86_64.so \
+      --project=/content/mem-colab/env -e 'using MacroEconometricModels; estimate_var(randn(60,3), 2)'
+```
+
+The sysimage is built with a portable `cpu_target` so typical Colab CPUs do not
+SIGILL. If the Release has no `.so`, the depot tarball is still the supported
+path.
+
+## What voids the guarantee
+
+`Pkg.update`, adding unpinned packages, or activating a different Manifest
+inside the notebook rebuilds / misses pkgimages. Re-download the Release asset
+or accept a cold precompile.
+
+## Maintenance policy
+
+| Topic | Policy |
+|---|---|
+| Supported matrix (v1) | One Julia version (Colab's current pin, 1.12.6) × linux-x86_64 only |
+| When to rebuild | Every package release tag that claims Colab assets; when Colab's Julia patch changes; when this Manifest must change for compat or security |
+| Who owns it | Release owner ensures the Colab workflow finished (or documents skip) before advertising Colab prebuilts |
+| Compatibility promise | Best-effort for that Colab pin only |
+| Expanding matrix | Extra OS/arch or extra Julia majors are out of scope unless Colab itself requires them |
+| Size budget | Soft cap 1.5 GiB; zstd; no unrelated global packages in the depot |
+| Security | Clean CI build only; publish SHA256; no secrets in the depot |
+| Deprecation | When Colab moves the pin, rebuild; mark old assets unsupported in the release notes |
+| Relationship to PrecompileTools | Package workload stays for all non-Colab users; keep `colab_precompile.jl` coherent with `src/precompile.jl` |
+| Failure modes | Depot OK without sysimage. Neither asset → package release still valid; release notes: “Colab prebuilt unavailable” |
+| Cost control | Tags / `workflow_dispatch` only — never every PR |
+| User voiding the guarantee | `Pkg.update` / unpinned deps → re-download or re-precompile |
+
+## Rebuild locally (maintainers)
+
+CI is the supported builder (`ubuntu-latest`, Julia 1.12.6, isolated
+`JULIA_DEPOT_PATH`). A Linux x86_64 machine with that Julia pin can reproduce:
+
+```bash
+# isolated depot + pack + best-effort sysimage
+OUT_DIR=/tmp/colab-dist environments/colab/build_depot.sh
+
+# depot only
+SKIP_SYSIMAGE=1 OUT_DIR=/tmp/colab-dist environments/colab/build_depot.sh
+```
+
+`colab_precompile.jl` is the execution file. Extend it in lockstep with
+`src/precompile.jl` whenever a Colab demo grows a new high-TTFX entry point.
+
+To refresh the in-repo Manifest on Julia 1.12.6:
+
+```bash
+julia --project=environments/colab -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+```
+
+The in-repo Manifest uses a path dep for local checks. The Manifest **inside
+the Release tarball** is rewritten to the GitHub URL so Colab does not see a
+CI filesystem path.
+
+## Explicit non-goals
+
+- Non-Colab lab / cluster / workshop distribution
+- macOS, Windows, or aarch64 assets
+- Committing `~/.julia/compiled` or `.so` into git
+- Auto-selecting a sysimage from `Pkg.add`
+- GPU / CUDA Colab images (CPU-only v1)
+- Replacing or weakening in-package PrecompileTools

--- a/environments/colab/build_depot.sh
+++ b/environments/colab/build_depot.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# Build the Colab-only depot tarball (and optionally a PackageCompiler sysimage).
+# Google Colab only (#610) — linux-x86_64, one Julia pin. Do not commit the
+# output; CI attaches it to the GitHub Release.
+#
+# Usage:
+#   environments/colab/build_depot.sh
+#
+# Environment:
+#   JULIA           julia executable (default: julia)
+#   OUT_DIR         output directory (default: ./colab-dist)
+#   PKG_VERSION     override version in asset names (default: root Project.toml)
+#   JULIA_PIN       expected VERSION string (default: 1.12.6)
+#   SKIP_SYSIMAGE   set to 1 to skip PackageCompiler
+#   GITHUB_REPO     used when rewriting Manifest repo-url
+#                   (default: FriedmanJP/MacroEconometricModels.jl)
+
+set -euo pipefail
+
+JULIA_PIN="${JULIA_PIN:-1.12.6}"
+JULIA="${JULIA:-julia}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OUT_DIR="${OUT_DIR:-${TMPDIR:-/tmp}/mem-colab-dist}"
+GITHUB_REPO="${GITHUB_REPO:-FriedmanJP/MacroEconometricModels.jl}"
+GITHUB_URL="https://github.com/${GITHUB_REPO}.git"
+SIZE_WARN_BYTES=$((1500 * 1024 * 1024))  # 1.5 GiB soft cap
+CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+
+if ! command -v zstd >/dev/null 2>&1; then
+    echo "error: zstd is required to pack the depot tarball" >&2
+    exit 1
+fi
+
+JULIA_VER="$("${JULIA}" --startup-file=no -e 'print(VERSION)')"
+if [[ "${JULIA_VER}" != "${JULIA_PIN}" ]]; then
+    echo "warning: julia reports VERSION=${JULIA_VER}, Colab pin is ${JULIA_PIN}" >&2
+    echo "warning: compiled images will not match Colab's native runtime" >&2
+fi
+
+if [[ -z "${PKG_VERSION:-}" ]]; then
+    PKG_VERSION="$("${JULIA}" --startup-file=no --project="${REPO_ROOT}" -e 'using Pkg; print(Pkg.project().version)')"
+fi
+
+REV="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/mem-colab.XXXXXX")"
+cleanup() { rm -rf "${STAGE}"; }
+trap cleanup EXIT
+
+BUNDLE="${STAGE}/mem-colab"
+DEPOT="${BUNDLE}/depot"
+ENV_DIR="${BUNDLE}/env"
+mkdir -p "${DEPOT}" "${ENV_DIR}" "${OUT_DIR}"
+
+export JULIA_DEPOT_PATH="${DEPOT}"
+export JULIA_PKG_PRECOMPILE_AUTO=1
+
+cp "${SCRIPT_DIR}/Project.toml" "${ENV_DIR}/Project.toml"
+
+echo "==> instantiate + add MacroEconometricModels@${REV} into isolated depot"
+"${JULIA}" --startup-file=no --project="${ENV_DIR}" -e "
+    using Pkg
+    Pkg.add(; url=raw\"${REPO_ROOT}\", rev=raw\"${REV}\")
+    Pkg.instantiate()
+    Pkg.precompile()
+"
+
+# Rewrite the local path so a Colab instantiate can fetch from GitHub if the
+# depot is incomplete. The packaged depot already contains the tree.
+MANIFEST="${ENV_DIR}/Manifest.toml"
+if [[ -f "${MANIFEST}" ]]; then
+    "${JULIA}" --startup-file=no -e "
+        path = raw\"${MANIFEST}\"
+        text = read(path, String)
+        text = replace(text, raw\"${REPO_ROOT}\" => raw\"${GITHUB_URL}\")
+        write(path, text)
+    "
+fi
+
+echo "==> run colab_precompile.jl"
+"${JULIA}" --startup-file=no --project="${ENV_DIR}" "${SCRIPT_DIR}/colab_precompile.jl"
+
+echo "==> smoke estimate_var (warm depot)"
+WARM_TIME="$("${JULIA}" --startup-file=no --project="${ENV_DIR}" -e '
+    using MacroEconometricModels, Random
+    t = @elapsed estimate_var(randn(MersenneTwister(0), 60, 3), 2)
+    println(round(t; digits=3))
+')"
+echo "warm estimate_var: ${WARM_TIME}s"
+
+# Drop caches that are not needed to load the package.
+rm -rf "${DEPOT}/logs" "${DEPOT}/compiled/v${JULIA_VER}/PackageCompiler" || true
+
+ASSET_STEM="mem-colab-depot-v${PKG_VERSION}-julia${JULIA_PIN}-linux-x86_64"
+TARBALL="${OUT_DIR}/${ASSET_STEM}.tar.zst"
+echo "==> pack ${TARBALL}"
+tar -I 'zstd -T0' -cf "${TARBALL}" -C "${STAGE}" mem-colab
+
+TARBALL_BYTES="$(wc -c < "${TARBALL}" | tr -d ' ')"
+if (( TARBALL_BYTES > SIZE_WARN_BYTES )); then
+    echo "warning: depot tarball is ${TARBALL_BYTES} bytes (> 1.5 GiB soft cap)" >&2
+fi
+
+SYSIMAGE_NAME="MacroEM-colab-v${PKG_VERSION}-julia${JULIA_PIN}-linux-x86_64.so"
+SYSIMAGE_PATH="${OUT_DIR}/${SYSIMAGE_NAME}"
+SYSIMAGE_STATUS="skipped"
+
+if [[ "${SKIP_SYSIMAGE:-0}" != "1" ]]; then
+    echo "==> PackageCompiler sysimage (best-effort)"
+    if "${JULIA}" --startup-file=no --project="${ENV_DIR}" -e "
+        using Pkg
+        Pkg.add(\"PackageCompiler\")
+        using PackageCompiler
+        PackageCompiler.create_sysimage(
+            [:MacroEconometricModels, :DataFrames];
+            sysimage_path=raw\"${SYSIMAGE_PATH}\",
+            project=raw\"${ENV_DIR}\",
+            precompile_execution_file=raw\"${SCRIPT_DIR}/colab_precompile.jl\",
+            cpu_target=raw\"${CPU_TARGET}\",
+        )
+    "; then
+        SYSIMAGE_STATUS="built"
+    else
+        echo "warning: PackageCompiler failed; publishing depot without sysimage" >&2
+        SYSIMAGE_STATUS="failed"
+        rm -f "${SYSIMAGE_PATH}"
+    fi
+fi
+
+SUMS="${OUT_DIR}/SHA256SUMS"
+{
+    (cd "${OUT_DIR}" && shasum -a 256 "$(basename "${TARBALL}")")
+    if [[ -f "${SYSIMAGE_PATH}" ]]; then
+        (cd "${OUT_DIR}" && shasum -a 256 "${SYSIMAGE_NAME}")
+    fi
+    (cd "${ENV_DIR}" && shasum -a 256 Project.toml Manifest.toml)
+} > "${SUMS}"
+
+cp "${ENV_DIR}/Project.toml" "${OUT_DIR}/Project.toml"
+cp "${ENV_DIR}/Manifest.toml" "${OUT_DIR}/Manifest.toml"
+
+{
+    echo "## Colab precompiled assets"
+    echo
+    echo "- Julia pin: \`${JULIA_PIN}\` (this build: \`${JULIA_VER}\`)"
+    echo "- Package version: \`${PKG_VERSION}\`"
+    echo "- Git rev: \`${REV}\`"
+    echo "- Depot tarball: \`$(basename "${TARBALL}")\` (${TARBALL_BYTES} bytes)"
+    echo "- Warm \`estimate_var\`: ${WARM_TIME}s"
+    echo "- Sysimage: ${SYSIMAGE_STATUS}"
+} | tee "${OUT_DIR}/SUMMARY.md"
+
+echo "==> done: ${OUT_DIR}"
+ls -lh "${OUT_DIR}"

--- a/environments/colab/colab_precompile.jl
+++ b/environments/colab/colab_precompile.jl
@@ -1,0 +1,27 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+# Colab-only execution file (#610). Tiny seeded workloads for the high-TTFX
+# paths Colab demos actually hit. Keep this aligned with src/precompile.jl;
+# a failure here should not be able to break a normal Pkg.add install.
+
+using Random
+using DataFrames
+using MacroEconometricModels
+
+rng = MersenneTwister(0)
+Y = randn(rng, 60, 3)
+yv = collect(Y[:, 1])
+X = Y[:, 2:3]
+
+m = estimate_var(Y, 2)
+irf(m, 8)
+fevd(m, 8)
+forecast(m, 4; ci_method=:none, rng=rng)
+report(devnull, m)
+estimate_reg(yv, X)
+estimate_bvar(Y, 2; n_draws=10, rng=rng)
+estimate_lp(Y, 1, 4)

--- a/environments/colab/colab_setup.ipynb
+++ b/environments/colab/colab_setup.ipynb
@@ -1,0 +1,65 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Julia 1.12.6",
+      "language": "julia",
+      "name": "julia-1.12"
+    },
+    "language_info": {
+      "file_extension": ".jl",
+      "mimetype": "application/julia",
+      "name": "julia",
+      "version": "1.12.6"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MacroEconometricModels.jl on Google Colab\n",
+        "\n",
+        "**Google Colab only.** This notebook loads the precompiled Linux x86_64 depot for Julia **1.12.6** (Colab 2026.07). Other OS/arch combinations and other Julia patches should use ordinary `Pkg.add`.\n",
+        "\n",
+        "Run the setup cell **before** any other `using`. `DEPOT_PATH` is fixed at startup — the cell mutates it instead of setting `ENV[\"JULIA_DEPOT_PATH\"]` after the kernel has launched."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "using Downloads\n",
+        "import Pkg\n",
+        "const PKG_VERSION = \"0.8.3\"\n",
+        "const JULIA_PIN = \"1.12.6\"\n",
+        "const ASSET = \"mem-colab-depot-v$(PKG_VERSION)-julia$(JULIA_PIN)-linux-x86_64.tar.zst\"\n",
+        "const URL = \"https://github.com/FriedmanJP/MacroEconometricModels.jl/releases/download/v$(PKG_VERSION)/$(ASSET)\"\n",
+        "const DEST = \"/content/mem-colab\"\n",
+        "const TARBALL = \"/tmp/$(ASSET)\"\n",
+        "const DRIVE = \"/content/drive/MyDrive/mem-colab\"\n",
+        "\n",
+        "if isdir(joinpath(DRIVE, \"depot\")) && !isdir(joinpath(DEST, \"depot\"))\n",
+        "    println(\"Restoring depot from Google Drive…\")\n",
+        "    cp(DRIVE, DEST; force=true)\n",
+        "elseif !isdir(joinpath(DEST, \"depot\"))\n",
+        "    println(\"Downloading \", ASSET)\n",
+        "    run(`apt-get install -y -qq zstd`)\n",
+        "    Downloads.download(URL, TARBALL)\n",
+        "    mkpath(\"/content\")\n",
+        "    run(`tar -I zstd -xf $(TARBALL) -C /content`)\n",
+        "end\n",
+        "\n",
+        "empty!(DEPOT_PATH)\n",
+        "push!(DEPOT_PATH, joinpath(DEST, \"depot\"))\n",
+        "Pkg.activate(joinpath(DEST, \"env\"))\n",
+        "\n",
+        "using MacroEconometricModels\n",
+        "@time estimate_var(randn(60, 3), 2)"
+      ]
+    }
+  ]
+}

--- a/test/core/test_colab_env.jl
+++ b/test/core/test_colab_env.jl
@@ -1,0 +1,63 @@
+# MacroEconometricModels.jl
+# Copyright (C) 2025-2026 Wookyung Chung <chung@friedman.jp>
+#
+# This file is part of MacroEconometricModels.jl.
+# Licensed under GPL-3.0-or-later. See LICENSE for details.
+
+# Contract tests for the Colab-only precompiled environment (#610).
+# These check the in-repo recipe, not a built depot tarball (that lives on the
+# GitHub Release and is produced by .github/workflows/colab-precompiled-env.yml).
+
+using Test
+
+const REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const COLAB_DIR = joinpath(REPO_ROOT, "environments", "colab")
+const COLAB_PIN = "1.12.6"
+
+@testset "Colab precompiled env (#610)" begin
+    @testset "recipe files exist" begin
+        @test isdir(COLAB_DIR)
+        @test isfile(joinpath(COLAB_DIR, "Project.toml"))
+        @test isfile(joinpath(COLAB_DIR, "Manifest.toml"))
+        @test isfile(joinpath(COLAB_DIR, "colab_precompile.jl"))
+        @test isfile(joinpath(COLAB_DIR, "README.md"))
+        @test isfile(joinpath(COLAB_DIR, "colab_setup.ipynb"))
+        @test isfile(joinpath(COLAB_DIR, "build_depot.sh"))
+        @test isfile(joinpath(REPO_ROOT, ".github", "workflows", "colab-precompiled-env.yml"))
+    end
+
+    @testset "Project.toml pins the package UUID" begin
+        proj = read(joinpath(COLAB_DIR, "Project.toml"), String)
+        @test occursin("14a6ec33-bcac-448e-845f-2fb6769698f1", proj)
+        @test occursin("MacroEconometricModels", proj)
+        @test occursin("DataFrames", proj)
+    end
+
+    @testset "README is Colab-only and names the pin" begin
+        readme = read(joinpath(COLAB_DIR, "README.md"), String)
+        @test occursin("Google Colab only", readme)
+        @test occursin("linux-x86_64", readme)
+        @test occursin(COLAB_PIN, readme)
+        @test occursin("JULIA_DEPOT_PATH", readme) || occursin("DEPOT_PATH", readme)
+        @test occursin("PrecompileTools", readme)
+    end
+
+    @testset "workflow is tag/dispatch only" begin
+        wf = read(joinpath(REPO_ROOT, ".github", "workflows", "colab-precompiled-env.yml"), String)
+        @test occursin("workflow_dispatch", wf)
+        @test occursin(COLAB_PIN, wf)
+        @test occursin("tags:", wf)
+        # Must not run on every PR (cost control).
+        @test !occursin(r"(?m)^  pull_request:", wf)
+    end
+
+    @testset "colab_precompile.jl is parseable and seeded" begin
+        src = read(joinpath(COLAB_DIR, "colab_precompile.jl"), String)
+        @test occursin("MersenneTwister", src)
+        @test occursin("estimate_var", src)
+        @test occursin("estimate_reg", src)
+        @test occursin("estimate_bvar", src)
+        @test occursin("estimate_lp", src)
+        Meta.parse("begin\n" * src * "\nend")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ const TEST_GROUPS = [
         "core/test_error_paths.jl",
         "core/test_display_backends.jl",
         "core/test_coverage_gaps.jl",
+        "core/test_colab_env.jl",
     ]),
     # Group 2: Bayesian & SVAR (heavy sampling + multi-start optimization)
     ("Bayesian & SVAR" => [
@@ -459,6 +460,7 @@ else
         @testset "Error Paths" begin include("core/test_error_paths.jl") end
         @testset "Display Backend Switching" begin include("core/test_display_backends.jl") end
         @testset "Coverage Gaps" begin include("core/test_coverage_gaps.jl") end
+        @testset "Colab precompiled env" begin include("core/test_colab_env.jl") end
 
         # Group 2: Bayesian & SVAR
         @testset "Bayesian Estimation" begin include("bvar/test_bayesian.jl") end


### PR DESCRIPTION
## Summary

Stacked on `feat/bellman-vfi` (#621). Ships **optional Google Colab-only precompiled assets** so a new Colab runtime does not pay a multi-minute cold precompile of MacroEconometricModels + Optim / NonlinearSolve / JuMP / Ipopt / DataFrames.

This is a parallel channel. General-registry `Pkg.add` and in-package `PrecompileTools` (`src/precompile.jl`) are unchanged.

**Version:** `0.8.3`.

**Julia pin:** Colab's live 2026.07 runtime is **1.12.6**, not the 1.10 LTS the issue text assumed. The pin follows the live runtime (the issue says to re-check `VERSION` on each release).

### Delivered

| Item | Location |
|---|---|
| Colab env pin | `environments/colab/{Project,Manifest}.toml` |
| Seeded workload | `environments/colab/colab_precompile.jl` (aligned with `src/precompile.jl`, plus `forecast` / `report`) |
| Maintainer + user README | `environments/colab/README.md` (scope, setup cells, Drive cache, maintenance contract, non-goals) |
| Notebook | `environments/colab/colab_setup.ipynb` |
| Builder | `environments/colab/build_depot.sh` |
| CI (tag / `workflow_dispatch` only) | `.github/workflows/colab-precompiled-env.yml` |
| Docs | `docs/src/getting_started.md` Colab section; changelog / citation / README / CONTRIBUTING |

Release assets (on tag, or dispatch with `upload_to_release`):

- `mem-colab-depot-v0.8.3-julia1.12.6-linux-x86_64.tar.zst` — isolated depot + `env/` (required)
- `MacroEM-colab-v0.8.3-julia1.12.6-linux-x86_64.so` — PackageCompiler, portable `cpu_target` (best-effort; depot is still published if this fails)
- `SHA256SUMS`, `Project.toml`, `Manifest.toml`

Interactive Colab kernels cannot set `JULIA_DEPOT_PATH` after startup. Setup cells mutate `DEPOT_PATH` then `Pkg.activate` the shipped env.

### Smoke (this PR)

- `test/core/test_colab_env.jl` — 25/25 (recipe files, UUID, Colab-only README, tag/dispatch-only workflow, parseable workload)
- `julia --project=environments/colab environments/colab/colab_precompile.jl` — OK
- Warm `estimate_var(randn(60,3), 2)` on the Colab env (macOS aarch64, already-compiled depot): **0.043s**
- `docs/verify_examples.jl docs/src/getting_started.md` — **OK**

A true clean-Linux cold-vs-warm comparison needs the Release tarball. The workflow writes warm-depot timing and tarball size into the job summary on first tag/`workflow_dispatch`. That run is not in this PR (workflow is tag/dispatch only, as specified).

### Stack / merge

Base is `feat/bellman-vfi` so the diff is Colab + the 0.8.3 bump only. After #621 lands, retarget this PR to `dev` (or merge this into #621 first). `Closes` does not auto-close on a non-default base — close #610 when this reaches `dev`/`main`.

Closes #610.

## Test plan

- [x] Contract tests `test/core/test_colab_env.jl`
- [x] `colab_precompile.jl` workload
- [x] `verify_examples.jl docs/src/getting_started.md`
- [ ] First `workflow_dispatch` of `Colab precompiled env` on this branch (optional before merge; required on the v0.8.3 tag)
- [ ] After the tag: download depot on a clean Linux/Colab session and confirm first `estimate_var` is far below a cold `Pkg.add` precompile