### PR TITLE
v0.9.7: identification/solver backlog (#814–#816, #829, #830)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroEconometricModels"
 uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["Wookyung Chung <chung@friedman.jp>"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -801,6 +801,7 @@ Heterogeneous-agent (Reiter/SSJ/Krusell-Smith), continuous-time (HJB/KFE), and O
 | `dsge_smoother(ss, data)` | RTS Kalman smoother for linear DSGE |
 | `dsge_particle_smoother(nss, data)` | FFBSi particle smoother for nonlinear DSGE |
 | `evaluate_policy(sol, grid)` | Evaluate policy function on grid |
+| `physical_nodes(sol)` | Collocation nodes in physical state levels |
 | `max_euler_error(sol, grid)` | Maximum Euler equation error |
 
 OLS, WLS, IV/2SLS, logit, probit, ordered, and multinomial estimation for cross-sectional data. See [Linear Regression](@ref regression_page) and [Binary Choice](@ref binary_choice_page) for theory and examples.

--- a/docs/src/api/dsge.md
+++ b/docs/src/api/dsge.md
@@ -77,6 +77,7 @@ max_euler_error
 ```@docs
 vfi_solver
 evaluate_value
+physical_nodes
 ```
 
 ---

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -6,6 +6,23 @@ output, not just documentation.
 
 ---
 
+## v0.9.7
+
+Patch on the `0.9` series: identification and solver follow-ups from the v0.9.5–v0.9.6 backlog (`#814`–`#816`, `#829`, `#830`). Downstream `[compat]` of `MacroEconometricModels = "0.9"` still resolves. **Changed numerical output**: `identify_uhlig` sign-normalizes uniquely determined columns, so previously sign-flipped penalty rotations now satisfy the imposed signs.
+
+**Correctness**
+
+- `identify_uhlig` sign-normalizes columns that carry a sign restriction after the search (zeros are preserved under a column sign flip). Uniquely determined rotations (`free_dim = 1`) no longer land on the sign-flipped Cholesky with a dummy penalty of 0.0 from a 0-parameter Nelder–Mead run (`#814`).
+- `compute_steady_state` on an infeasible model throws `DSGESolveError` from the residual gate rather than a LinearSolve world-age `MethodError` on the QR-fallback path (`#816`).
+
+**New**
+
+- IV-GMM first-stage F: pass `X` and `Z` to `estimate_gmm` to store `first_stage_F` (Stock–Yogo partial F) on `GMMModel`; `report` / `gmm_summary` print it and warn when F < 10 (`#815`).
+- `physical_nodes(sol)` rescales `ProjectionSolution.collocation_nodes` from Chebyshev `[-1, 1]` to physical state levels. The field comment documents the convention (`#829`).
+- `estimate_structural_dfm` accepts `:lewis_tvv`, `:sv_em`, and `:gmm_moments` (plus `id_kwargs` forwarded to `compute_Q`) (`#830`).
+
+---
+
 ## v0.9.6
 
 Minor release on the `0.9` series: statistical identification from volatility dynamics —

--- a/docs/src/citation.md
+++ b/docs/src/citation.md
@@ -10,7 +10,7 @@ version.
 
 Plain-text (AEA style):
 
-> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.9.6. Zenodo.
+> Chung, Wookyung. 2026. *MacroEconometricModels.jl*, version 0.9.7. Zenodo.
 > [https://doi.org/10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170).
 
 BibTeX:
@@ -57,7 +57,7 @@ See [Utilities & Display API](@ref api_utilities) for the full `refs` signature.
 | Field | Value |
 |-------|-------|
 | Author | Wookyung Chung (`chung@friedman.jp`) |
-| Version | 0.9.6 |
+| Version | 0.9.7 |
 | Repository | [github.com/FriedmanJP/MacroEconometricModels.jl](https://github.com/FriedmanJP/MacroEconometricModels.jl) |
 | License | GPL-3.0-or-later |
 | Software DOI | [10.5281/zenodo.18439170](https://doi.org/10.5281/zenodo.18439170) |

--- a/docs/src/dsge_nonlinear.md
+++ b/docs/src/dsge_nonlinear.md
@@ -530,7 +530,7 @@ Five refinement rounds grow the 5-node ``\mu = 1`` grid into a 21-node grid with
 
 ### Evaluating the Policy Function
 
-`evaluate_policy` maps a state vector to the full vector of endogenous variables using the stored Chebyshev coefficients. The argument is the **lagged** state ``x_{t-1}`` in physical units, and the return value is the current-period vector of all ``n`` endogenous variables in `spec.varnames` order — the same ``v_t = [x_{t-1}; \varepsilon_t]`` convention the perturbation solutions use.
+`evaluate_policy` maps a state vector to the full vector of endogenous variables using the stored Chebyshev coefficients. The argument is the **lagged** state ``x_{t-1}`` in physical units, and the return value is the current-period vector of all ``n`` endogenous variables in `spec.varnames` order — the same ``v_t = [x_{t-1}; \varepsilon_t]`` convention the perturbation solutions use. `ProjectionSolution.collocation_nodes` stores the same points in Chebyshev coordinates on ``[-1, 1]``; [`physical_nodes`](@ref)`(sol)` rescales them to levels so a row can be passed to `evaluate_policy` / `evaluate_value`.
 
 ```@example dsge_nonlinear
 x_lag = [37.0, 1.0]                     # K_{t-1} = 37, A_{t-1} = 1
@@ -615,7 +615,7 @@ PFI reaches the ``10^{-8}`` sup-norm target in 223 iterations here — roughly f
 | `state_bounds` | `Matrix{T}` | ``n_x \times 2`` state domain bounds |
 | `grid_type` | `Symbol` | `:tensor` or `:smolyak` |
 | `degree` | `Int` | Polynomial degree (tensor) or highest Smolyak level reached |
-| `collocation_nodes` | `Matrix{T}` | ``n_{\text{nodes}} \times n_x`` grid points in ``[-1, 1]`` |
+| `collocation_nodes` | `Matrix{T}` | ``n_{\text{nodes}} \times n_x`` Chebyshev coordinates on ``[-1, 1]``. Physical levels: [`physical_nodes`](@ref)`(sol)` |
 | `residual_norm` | `T` | Final ``\|R\|`` residual (collocation) or sup-norm (PFI/VFI); fit **at the nodes only** |
 | `n_basis` | `Int` | Number of basis functions |
 | `multi_indices` | `Matrix{Int}` | ``n_b \times n_x`` multi-index matrix |

--- a/docs/src/factormodels.md
+++ b/docs/src/factormodels.md
@@ -689,7 +689,8 @@ The first structural shock moves `UNRATE` by ``-0.0481`` and `FEDFUNDS` by ``-0.
 
 | Keyword | Type | Default | Description |
 |---------|------|---------|-------------|
-| `identification` | `Symbol` | `:cholesky` | `:cholesky`, `:sign`, `:long_run`, `:proxy`, `:narrative`, ICA/ML/heteroskedastic `compute_Q` methods, `:arias`/`:uhlig` |
+| `identification` | `Symbol` | `:cholesky` | `:cholesky`, `:sign`, `:long_run`, `:proxy`, `:narrative`, ICA/ML/heteroskedastic `compute_Q` methods (including `:lewis_tvv`, `:sv_em`, `:gmm_moments`), `:arias`/`:uhlig` |
+| `id_kwargs` | `NamedTuple` | empty | Extra keywords forwarded to `compute_Q` for statistical-ID methods |
 | `target_vars` | `Vector` | `1:q` | Observables whose long-run responses are lower-triangular (`:long_run`) |
 | `method` | `Symbol` | `:fglr` | `:fglr` (FGLR 2009) or `:gdfm_var` (legacy two-sided) |
 | `r` | `Int` | `q` | Static factors; must satisfy ``r \ge q`` |

--- a/docs/src/gmm.md
+++ b/docs/src/gmm.md
@@ -8,6 +8,7 @@
 - **Model & moment selection**: Andrews-Lu (2001) MMSC criteria
 - **`estimate_smm`**: parameter estimation when moments are available only through simulation
 - **Linear GMM utilities**: closed-form solvers and robust sandwich covariances for IV-type models
+- **IV first-stage F**: pass `X` and `Z` to `estimate_gmm` to report the Stock–Yogo partial F on `GMMModel`
 - **StatsAPI interface**: `coef`, `vcov`, `stderror`, `confint`, `nobs`, and `report` for both estimators
 
 This page documents the general-purpose GMM/SMM surface. For Local Projections estimated by GMM see [Local Projections](@ref lp_page); for DSGE parameter estimation with `method=:smm` see [DSGE Estimation](@ref dsge_estimation).
@@ -32,7 +33,8 @@ data = hcat(y, X, Z)
 # Moment conditions: E[Z_t (y_t − X_t β)] = 0  →  3 moments, 1 parameter
 iv_moments(theta, d) = d[:, 3:5] .* (d[:, 1] .- d[:, 2] .* theta[1])
 
-m_iv = estimate_gmm(iv_moments, [0.0], data; weighting=:two_step)
+m_iv = estimate_gmm(iv_moments, [0.0], data; weighting=:two_step,
+                    X=reshape(X, :, 1), Z=Z)
 report(m_iv)
 ```
 
@@ -161,7 +163,8 @@ The same choices are wrapped in the `GMMWeighting` specification, stored on ever
 ```julia
 estimate_gmm(moment_fn, theta0, data;
              weighting=:two_step, max_iter=100, tol=1e-8,
-             hac=true, bandwidth=0, bounds=nothing)
+             hac=true, bandwidth=0, bounds=nothing,
+             X=nothing, Z=nothing, endogenous=nothing)
 ```
 
 | Keyword | Type | Default | Description |
@@ -172,6 +175,9 @@ estimate_gmm(moment_fn, theta0, data;
 | `hac` | `Bool` | `true` | Use HAC correction when building the optimal weighting matrix |
 | `bandwidth` | `Int` | `0` | HAC bandwidth (`0` = automatic Newey-West selection) |
 | `bounds` | `ParameterTransform` or `nothing` | `nothing` | Optional box constraints via bijective transforms; SEs corrected by the delta method |
+| `X` | `AbstractMatrix` or `nothing` | `nothing` | IV regressors; with `Z`, fills `first_stage_F` |
+| `Z` | `AbstractMatrix` or `nothing` | `nothing` | IV instruments; with `X`, fills `first_stage_F` |
+| `endogenous` | `AbstractVector{<:Integer}` or `nothing` | `nothing` | Endogenous columns of `X` (default: every non-constant column) |
 
 The optimizer is LBFGS with a Nelder-Mead fallback. When `bounds` are supplied the search runs in an unconstrained space via `ParameterTransform`, so parameters such as variances or probabilities can be constrained without penalty terms. `hac` governs only the weighting matrix; the ``\Omega`` entering the identity-weighting sandwich is always the Bartlett long-run covariance.
 
@@ -191,8 +197,9 @@ The optimizer is LBFGS with a Nelder-Mead fallback. When `bounds` are supplied t
 | `J_pvalue` | `T` | J-test p-value (`NaN` under identity weighting) |
 | `converged` | `Bool` | Optimizer convergence flag |
 | `iterations` | `Int` | Total iterations |
+| `first_stage_F` | `T` | Minimum excluded-instrument partial first-stage F when `X` and `Z` are supplied (IV-GMM); `NaN` otherwise |
 
-The `report` method prints the specification, a Stata-style coefficient table, and — when overidentified — the Hansen J-test. `coef`, `vcov`, `stderror`, `confint`, `nobs`, and `dof` follow the StatsAPI convention. Both `GMMModel` and `SMMModel` subtype the abstract [`AbstractGMMModel`](@ref), on which the shared `report` and StatsAPI accessors dispatch.
+The `report` method prints the specification, a Stata-style coefficient table, and — when overidentified — the Hansen J-test. When `first_stage_F` is finite it is printed as a weak-instrument diagnostic (Stock & Yogo 2005), with a warning if the statistic is below 10. `coef`, `vcov`, `stderror`, `confint`, `nobs`, and `dof` follow the StatsAPI convention. Both `GMMModel` and `SMMModel` subtype the abstract [`AbstractGMMModel`](@ref), on which the shared `report` and StatsAPI accessors dispatch.
 
 ---
 

--- a/src/MacroEconometricModels.jl
+++ b/src/MacroEconometricModels.jl
@@ -813,7 +813,7 @@ export simulate, estimate_dsge
 export solve_lyapunov, analytical_moments
 export determinacy_region, determinacy_boundary, determinacy_label, DETERMINACY_CODES
 export pruned_state_space
-export evaluate_policy, evaluate_value, max_euler_error, vfi_solver
+export evaluate_policy, evaluate_value, physical_nodes, max_euler_error, vfi_solver
 
 # Accessors
 export nshocks, is_determined, is_stable

--- a/src/core/serial/reconstruct.jl
+++ b/src/core/serial/reconstruct.jl
@@ -110,6 +110,10 @@ function _from_serializable(::Type{T}, p::AbstractDict, ::Int) where {T}
                 push!(args, nothing)
                 continue
             end
+            if f === :first_stage_F
+                push!(args, NaN)   # IV-GMM diagnostic added in v0.9.7 (#815)
+                continue
+            end
             throw(SerializationError(
                 "field '$key' of $(nameof(T)) is missing from the payload — the file " *
                 "was saved by an older package version, before this field existed. " *

--- a/src/core/uhlig.jl
+++ b/src/core/uhlig.jl
@@ -237,16 +237,21 @@ function _uhlig_penalty(theta_all::AbstractVector{T}, restrictions::SVARRestrict
         return T(1e10)
     end
 
-    # Compute IRF
-    irf = structural_irf(Phi, L, Q, horizon)
+    _uhlig_penalty_from_Q(Q, restrictions, Phi, L, model, horizon; penalty_weight=pw)
+end
 
-    # Compute standard deviations for normalization
+"""Penalty of a candidate rotation `Q` (Uhlig 2005 §3.3). Lower is better."""
+function _uhlig_penalty_from_Q(Q::AbstractMatrix{T}, restrictions::SVARRestrictions,
+                                Phi::Vector{Matrix{T}}, L::LowerTriangular{T,Matrix{T}},
+                                model::VARModel{T}, horizon::Int;
+                                penalty_weight::Real=100) where {T<:AbstractFloat}
+    pw = T(penalty_weight)
+    n = size(Q, 1)
+    irf = structural_irf(Phi, L, Q, horizon)
     sigma = zeros(T, n)
     for i in 1:n
         sigma[i] = sqrt(max(model.Sigma[i, i], eps(T)))
     end
-
-    # Penalty computation: Uhlig (2005) §3.3
     total_penalty = zero(T)
     for sr in restrictions.signs
         sr isa SignRestriction || continue
@@ -256,8 +261,35 @@ function _uhlig_penalty(theta_all::AbstractVector{T}, restrictions::SVARRestrict
         x = -normalized                    # >0 ⇔ violated
         total_penalty += x <= zero(T) ? x : pw * x
     end
-
     total_penalty
+end
+
+"""
+Flip columns of `Q` that have sign restrictions when the flip lowers the
+penalty. Zero restrictions are homogeneous in the column, so a sign flip is
+always free. This is required when a column is uniquely determined
+(`free_dim == 1`): the SVD null-space basis has an arbitrary sign, and a
+0-parameter Nelder–Mead run never evaluates the objective (reports 0.0).
+"""
+function _uhlig_sign_normalize(Q::AbstractMatrix{T}, restrictions::SVARRestrictions,
+                                Phi::Vector{Matrix{T}}, L::LowerTriangular{T,Matrix{T}},
+                                model::VARModel{T}, horizon::Int;
+                                penalty_weight::Real=100) where {T<:AbstractFloat}
+    shocks = unique(Int[sr.shock for sr in restrictions.signs if sr isa SignRestriction])
+    isempty(shocks) && return Matrix{T}(Q)
+    Qbest = Matrix{T}(Q)
+    for j in shocks
+        pen0 = _uhlig_penalty_from_Q(Qbest, restrictions, Phi, L, model, horizon;
+                                     penalty_weight=penalty_weight)
+        Qflip = copy(Qbest)
+        Qflip[:, j] .*= -one(T)
+        pen1 = _uhlig_penalty_from_Q(Qflip, restrictions, Phi, L, model, horizon;
+                                     penalty_weight=penalty_weight)
+        if pen1 < pen0
+            Qbest = Qflip
+        end
+    end
+    Qbest
 end
 
 """
@@ -315,6 +347,12 @@ enforced as hard constraints via null-space projection.
 
 The penalty is Uhlig (2005): `x = -normalized`, then `x` if satisfied and
 `penalty_weight * x` if violated. Lower `penalty` is better.
+
+Columns that carry a sign restriction are sign-normalized after the search:
+a column sign flip preserves linear zero restrictions, so the uniquely
+determined (null-space dimension 1) case is pinned by the sign rather than
+by the SVD basis orientation. The stored `penalty` is always recomputed from
+the returned `Q`.
 
 Rejection restrictions other than [`SignRestriction`](@ref) are not part of
 the penalty or the `converged` flag; mixed containers throw `ArgumentError`.
@@ -386,84 +424,93 @@ function identify_uhlig(model::VARModel{T}, restrictions::SVARRestrictions, hori
     n_params = _uhlig_n_params(n, restrictions)
 
     pw = T(penalty_weight)
-    # Objective closure
-    obj = theta -> _uhlig_penalty(theta, restrictions, Phi, L, model, max_h, n;
-                                  penalty_weight=pw, C1=C1)
 
-    # =========================================================================
-    # Phase 1: Coarse search from random starting points (multi-threaded)
-    # =========================================================================
-    results_phase1 = Vector{Tuple{T, Vector{T}}}(undef, n_starts)
-    fill!(results_phase1, (T(Inf), zeros(T, n_params)))
+    # n_params == 0: every column is uniquely determined up to sign (null-space
+    # dimension 1). Nelder–Mead on an empty θ reports minimum 0.0 without
+    # evaluating the penalty (#814); skip the search and sign-normalize below.
+    Q = if n_params == 0
+        _uhlig_build_Q(T[], restrictions, Phi, L, n; B=model.B, C1=C1)
+    else
+        obj = theta -> _uhlig_penalty(theta, restrictions, Phi, L, model, max_h, n;
+                                      penalty_weight=pw, C1=C1)
+        # =====================================================================
+        # Phase 1: Coarse search from random starting points (multi-threaded)
+        # =====================================================================
+        results_phase1 = Vector{Tuple{T, Vector{T}}}(undef, n_starts)
+        fill!(results_phase1, (T(Inf), zeros(T, n_params)))
 
-    seeds1 = rand(rng, UInt64, n_starts)
-    Threads.@threads for i in 1:n_starts
-        local_rng = Random.Xoshiro(seeds1[i])
-        theta0 = rand(local_rng, T, n_params) .* T(2π)
+        seeds1 = rand(rng, UInt64, n_starts)
+        Threads.@threads for i in 1:n_starts
+            local_rng = Random.Xoshiro(seeds1[i])
+            theta0 = rand(local_rng, T, n_params) .* T(2π)
 
-        res = try
-            Optim.optimize(obj, theta0, Optim.NelderMead(),
-                Optim.Options(iterations=max_iter_coarse,
-                              f_reltol=tol_coarse))
-        catch err
-            _is_rejectable_draw_error(err) ? nothing : rethrow(err)
-        end
+            res = try
+                Optim.optimize(obj, theta0, Optim.NelderMead(),
+                    Optim.Options(iterations=max_iter_coarse,
+                                  f_reltol=tol_coarse))
+            catch err
+                _is_rejectable_draw_error(err) ? nothing : rethrow(err)
+            end
 
-        if res !== nothing
-            val = Optim.minimum(res)
-            if isfinite(val)
-                results_phase1[i] = (val, Optim.minimizer(res))
+            if res !== nothing
+                val = Optim.minimum(res)
+                if isfinite(val)
+                    results_phase1[i] = (val, Optim.minimizer(res))
+                end
             end
         end
-    end
 
-    best_idx = argmin(first.(results_phase1))
-    best_val, best_theta = results_phase1[best_idx]
-    best_val == T(Inf) && error("All starting points failed in Phase 1")
+        best_idx = argmin(first.(results_phase1))
+        best_val, best_theta = results_phase1[best_idx]
+        best_val == T(Inf) && error("All starting points failed in Phase 1")
 
-    # =========================================================================
-    # Phase 2: Local refinement from best solution (multi-threaded)
-    # =========================================================================
-    results_phase2 = Vector{Tuple{T, Vector{T}}}(undef, n_refine)
-    fill!(results_phase2, (T(Inf), zeros(T, n_params)))
-    best_theta_snap = copy(best_theta)
+        # =====================================================================
+        # Phase 2: Local refinement from best solution (multi-threaded)
+        # =====================================================================
+        results_phase2 = Vector{Tuple{T, Vector{T}}}(undef, n_refine)
+        fill!(results_phase2, (T(Inf), zeros(T, n_params)))
+        best_theta_snap = copy(best_theta)
 
-    seeds2 = rand(rng, UInt64, n_refine)
-    Threads.@threads for i in 1:n_refine
-        local_rng = Random.Xoshiro(seeds2[i])
-        theta0 = if i == 1
-            copy(best_theta_snap)
-        else
-            best_theta_snap .+ T(0.01) .* randn(local_rng, T, n_params)
-        end
+        seeds2 = rand(rng, UInt64, n_refine)
+        Threads.@threads for i in 1:n_refine
+            local_rng = Random.Xoshiro(seeds2[i])
+            theta0 = if i == 1
+                copy(best_theta_snap)
+            else
+                best_theta_snap .+ T(0.01) .* randn(local_rng, T, n_params)
+            end
 
-        res = try
-            Optim.optimize(obj, theta0, Optim.NelderMead(),
-                Optim.Options(iterations=max_iter_fine,
-                              f_reltol=tol_fine))
-        catch err
-            _is_rejectable_draw_error(err) ? nothing : rethrow(err)
-        end
+            res = try
+                Optim.optimize(obj, theta0, Optim.NelderMead(),
+                    Optim.Options(iterations=max_iter_fine,
+                                  f_reltol=tol_fine))
+            catch err
+                _is_rejectable_draw_error(err) ? nothing : rethrow(err)
+            end
 
-        if res !== nothing
-            val = Optim.minimum(res)
-            if isfinite(val)
-                results_phase2[i] = (val, Optim.minimizer(res))
+            if res !== nothing
+                val = Optim.minimum(res)
+                if isfinite(val)
+                    results_phase2[i] = (val, Optim.minimizer(res))
+                end
             end
         end
-    end
 
-    for (val, theta) in results_phase2
-        if val < best_val
-            best_val = val
-            best_theta = theta
+        for (val, theta) in results_phase2
+            if val < best_val
+                best_val = val
+                best_theta = theta
+            end
         end
+        _uhlig_build_Q(best_theta, restrictions, Phi, L, n; B=model.B, C1=C1)
     end
 
     # =========================================================================
     # Build final result
     # =========================================================================
-    Q = _uhlig_build_Q(best_theta, restrictions, Phi, L, n; B=model.B, C1=C1)
+    Q = _uhlig_sign_normalize(Q, restrictions, Phi, L, model, max_h; penalty_weight=pw)
+    best_val = _uhlig_penalty_from_Q(Q, restrictions, Phi, L, model, max_h;
+                                     penalty_weight=pw)
     irf_full = structural_irf(Phi, L, Q, max_h)
 
     # Check convergence: all sign restrictions satisfied?

--- a/src/dsge/projection.jl
+++ b/src/dsge/projection.jl
@@ -985,6 +985,19 @@ function _proj_eval(coeffs::Matrix{T}, multi_indices::Matrix{Int},
 end
 
 """
+    physical_nodes(sol::ProjectionSolution) -> Matrix
+
+Collocation nodes in physical state units (`n_nodes × nx`).
+
+`sol.collocation_nodes` stores Chebyshev coordinates on `[-1, 1]`. This
+rescales each column through `sol.state_bounds` so rows can be passed to
+[`evaluate_value`](@ref) / [`evaluate_policy`](@ref), which take levels.
+"""
+function physical_nodes(sol::ProjectionSolution{T}) where {T}
+    Matrix{T}(_scale_from_unit(sol.collocation_nodes, sol.state_bounds))
+end
+
+"""
     evaluate_policy(sol::ProjectionSolution{T}, x_state::AbstractVector) -> Vector{T}
 
 Evaluate the global policy function at a state vector.

--- a/src/dsge/steady_state.jl
+++ b/src/dsge/steady_state.jl
@@ -156,8 +156,28 @@ function compute_steady_state(spec::ModelSpec{T};
     # silently-wrong steady state (#214).
     lower = fill(T(-Inf), n)
     upper = fill(T(Inf), n)
-    y_ss = _nonlinearsolve_steady_state(spec, lower, upper;
-                initial_guess=initial_guess, algorithm=algorithm)
+    y_ss = try
+        _nonlinearsolve_steady_state(spec, lower, upper;
+                    initial_guess=initial_guess, algorithm=algorithm)
+    catch e
+        # LinearSolve's generated QR-fallback (`defaultalg_symbol(::QRFactorization)`)
+        # can throw a world-age MethodError on infeasible systems instead of
+        # returning a failed retcode (#816). Surface that as the residual-gate
+        # DSGESolveError so callers mapping DSGESolveError → model/solve stay typed.
+        e isa MethodError || rethrow()
+        y_fail = if initial_guess !== nothing
+            Vector{T}(initial_guess)
+        elseif !isempty(spec.steady_state)
+            Vector{T}(spec.steady_state)
+        else
+            ones(T, n)
+        end
+        resnorm, bad = _ss_residual_norm(spec, y_fail)
+        throw(DSGESolveError(
+            "Numerical steady state did not satisfy the equilibrium conditions " *
+            "(‖F‖∞ = $resnorm > $(SS_RESIDUAL_TOL); offending equation index/indices: $bad). " *
+            "Supply an analytical ss_fn or a better initial_guess, or add bounds via a constrained solver."))
+    end
     resnorm, bad = _ss_residual_norm(spec, y_ss)
     resnorm > T(SS_RESIDUAL_TOL) && throw(DSGESolveError(
         "Numerical steady state did not satisfy the equilibrium conditions " *
@@ -236,7 +256,10 @@ function _nonlinearsolve_steady_state(spec::ModelSpec{T}, lower::Vector{T}, uppe
     end
 
     alg = algorithm !== nothing ? algorithm : NonlinearSolve.TrustRegion()
-    sol = NonlinearSolve.solve(prob, alg; abstol=T(1e-10), maxiters=5000)
+    # invokelatest: LinearSolve's @generated QR-fallback can be stale in the
+    # world that compiled this method (#816). A leftover MethodError is caught
+    # by compute_steady_state and rewritten as DSGESolveError.
+    sol = Base.invokelatest(NonlinearSolve.solve, prob, alg; abstol=T(1e-10), maxiters=5000)
 
     if !NonlinearSolve.SciMLBase.successful_retcode(sol.retcode)
         @warn "Steady state solver did not converge (retcode = $(sol.retcode))"

--- a/src/dsge/types.jl
+++ b/src/dsge/types.jl
@@ -345,7 +345,8 @@ Fields:
 - `state_bounds` — `nx × 2` domain bounds `[lower upper]` per state
 - `grid_type` — `:tensor` or `:smolyak`
 - `degree` — polynomial degree (tensor) or Smolyak level μ
-- `collocation_nodes` — `n_nodes × nx` grid points
+- `collocation_nodes` — `n_nodes × nx` Chebyshev coordinates on `[-1, 1]`;
+  physical levels are `physical_nodes(sol)` (via `state_bounds`)
 - `residual_norm` — final `||R||`
 - `n_basis` — number of basis functions
 - `multi_indices` — `n_basis × nx` multi-index matrix
@@ -374,7 +375,7 @@ struct ProjectionSolution{T<:AbstractFloat}
     state_bounds::Matrix{T}         # nx × 2 ([lower upper] per state)
     grid_type::Symbol               # :tensor or :smolyak
     degree::Int                     # polynomial degree (tensor) or Smolyak level μ
-    collocation_nodes::Matrix{T}    # n_nodes × nx
+    collocation_nodes::Matrix{T}    # n_nodes × nx, Chebyshev coords on [-1, 1]; see physical_nodes
     residual_norm::T                # final ||R||
     n_basis::Int
     multi_indices::Matrix{Int}      # n_basis × nx

--- a/src/factor/structural.jl
+++ b/src/factor/structural.jl
@@ -162,12 +162,14 @@ const _SDFM_ID_METHODS = (
     :cholesky, :sign, :narrative, :long_run, :proxy,
     :fastica, :jade, :sobi, :dcov, :hsic,
     :student_t, :mixture_normal, :pml, :skew_normal, :nongaussian_ml,
+    :gmm_moments, :lewis_tvv, :sv_em,
     :markov_switching, :garch, :smooth_transition, :external_volatility,
     :arias, :uhlig,
 )
 const _SDFM_COMPUTE_Q_METHODS = (
     :narrative, :fastica, :jade, :sobi, :dcov, :hsic,
     :student_t, :mixture_normal, :pml, :skew_normal, :nongaussian_ml,
+    :gmm_moments, :lewis_tvv, :sv_em,
     :markov_switching, :garch, :smooth_transition, :external_volatility,
 )
 
@@ -190,7 +192,9 @@ legacy two-sided GDFM-factor VAR.
 - `q`: Number of dynamic / common shocks
 
 # Keyword Arguments
-- `identification::Symbol=:cholesky`: Identification method (:cholesky or :sign)
+- `identification::Symbol=:cholesky`: Identification method (`:cholesky`, `:sign`,
+  `:long_run`, `:proxy`, `:narrative`, ICA/ML/heteroskedastic `compute_Q` methods
+  including `:lewis_tvv`/`:sv_em`/`:gmm_moments`, `:arias`, `:uhlig`)
 - `p::Union{Int,Symbol}=1`: VAR lag order, or `:aic`/`:bic`/`:hq` over `1:p_max`
 - `p_max::Int=8`: Grid upper bound when `p` is a criterion
 - `check_stability::Bool=true`: Warn when the factor-VAR companion modulus is ≥ 1
@@ -211,6 +215,7 @@ legacy two-sided GDFM-factor VAR.
 - `varnames::Union{Nothing,Vector{String}}=nothing`: Panel variable names (length N)
 - `shock_names::Union{Nothing,Vector{String}}=nothing`: Structural shock names (length q)
 - `rng::AbstractRNG=Random.default_rng()`: RNG for sign-restriction search
+- `id_kwargs::NamedTuple`: Extra keywords forwarded to `compute_Q` for statistical-ID methods
 
 # Returns
 `StructuralDFM{T}` with identified factor IRFs mapped to all N panel variables.
@@ -257,6 +262,7 @@ function estimate_structural_dfm(X::AbstractMatrix{T}, q::Int;
     seed::Union{Integer,Nothing}=nothing,
     instrument::Union{Nothing,AbstractVector}=nothing,
     normalize::Union{Nothing,Tuple}=nothing,
+    id_kwargs::NamedTuple=NamedTuple(),
 ) where {T<:AbstractFloat}
     rng = _resolve_repro_rng(rng, seed)
 
@@ -277,7 +283,7 @@ function estimate_structural_dfm(X::AbstractMatrix{T}, q::Int;
         target_vars=target_vars, restrictions=restrictions,
         transition_var=transition_var, regime_indicator=regime_indicator,
         varnames=varnames, shock_names=shock_names, rng=rng, seed=seed,
-        standardize=standardize)
+        standardize=standardize, id_kwargs=id_kwargs)
 end
 
 @float_fallback estimate_structural_dfm X
@@ -386,6 +392,7 @@ function estimate_structural_dfm(gdfm::GeneralizedDynamicFactorModel{T};
     standardize::Bool=true,
     instrument::Union{Nothing,AbstractVector}=nothing,
     normalize::Union{Nothing,Tuple}=nothing,
+    id_kwargs::NamedTuple=NamedTuple(),
 ) where {T<:AbstractFloat}
     rng = _resolve_repro_rng(rng, seed)
 
@@ -433,12 +440,12 @@ function estimate_structural_dfm(gdfm::GeneralizedDynamicFactorModel{T};
             sign_check, sign_restrictions, restriction_space, store_all,
             max_draws, narrative_check, target_vars, restrictions,
             transition_var, regime_indicator, vn, sn, rng, standardize,
-            instrument, normalize)
+            instrument, normalize, id_kwargs)
     else
         _estimate_sdfm_gdfm_var(gdfm, q, p, p_max, check_stability, H, identification, sign_check, sign_restrictions,
             restriction_space, store_all, max_draws, narrative_check, target_vars,
             restrictions, transition_var, regime_indicator, vn, sn, rng,
-            instrument, normalize)
+            instrument, normalize, id_kwargs)
     end
     return _with_manifest(result, capture_manifest(; seed=seed,
         settings=Dict{String,Any}("identification" => String(identification),
@@ -456,7 +463,7 @@ function _estimate_sdfm_fglr(gdfm::GeneralizedDynamicFactorModel{T}, q::Int, r::
     max_draws::Int, narrative_check, target_vars, restrictions,
     transition_var, regime_indicator, vn::Vector{String}, sn::Vector{String},
     rng::AbstractRNG, standardize::Bool,
-    instrument, normalize) where {T<:AbstractFloat}
+    instrument, normalize, id_kwargs::NamedTuple=NamedTuple()) where {T<:AbstractFloat}
 
     X = gdfm.X
     T_obs, N = size(X)
@@ -482,7 +489,8 @@ function _estimate_sdfm_fglr(gdfm::GeneralizedDynamicFactorModel{T}, q::Int, r::
                             sign_check, sign_restrictions, restriction_space, store_all,
                             max_draws, narrative_check, target_vars, restrictions,
                             transition_var, regime_indicator,
-                            rng, vn, sn, X, standardize, units, instrument, normalize)
+                            rng, vn, sn, X, standardize, units, instrument, normalize,
+                            id_kwargs)
     B0 = from_var_Q ? Matrix{T}(safe_cholesky(factor_var.Sigma) * H_id) : Matrix{T}(K * H_id)
 
     structural_irf = _fglr_panel_irf(factor_var, Lambda, B0, H; X=X,
@@ -518,7 +526,8 @@ function _fglr_identify_H(Lambda::AbstractMatrix{T}, K::AbstractMatrix{T},
     store_all::Bool, max_draws::Int, narrative_check, target_vars, restrictions,
     transition_var, regime_indicator, rng::AbstractRNG,
     vn::Vector{String}, sn::Vector{String}, X, standardize::Bool,
-    units::Symbol, instrument=nothing, normalize=nothing) where {T<:AbstractFloat}
+    units::Symbol, instrument=nothing, normalize=nothing,
+    id_kwargs::NamedTuple=NamedTuple()) where {T<:AbstractFloat}
 
     q = size(K, 2)
     r = size(K, 1)
@@ -586,7 +595,8 @@ function _fglr_identify_H(Lambda::AbstractMatrix{T}, K::AbstractMatrix{T},
         "identification must be one of $(_SDFM_ID_METHODS), got :$identification"))
     Q = compute_Q(factor_var, identification; horizon=H_irf, check_func=sign_check,
                   narrative_check=narrative_check, max_draws=max_draws,
-                  transition_var=transition_var, regime_indicator=regime_indicator, rng=rng)
+                  transition_var=transition_var, regime_indicator=regime_indicator, rng=rng,
+                  id_kwargs...)
     return Matrix{T}(Q), nothing, one(T), true, nothing, nanF
 end
 
@@ -889,7 +899,8 @@ function _estimate_sdfm_gdfm_var(gdfm::GeneralizedDynamicFactorModel{T}, q::Int,
     restriction_space::Symbol, store_all::Bool, max_draws::Int,
     narrative_check, target_vars, restrictions, transition_var, regime_indicator,
     vn::Vector{String}, sn::Vector{String}, rng::AbstractRNG,
-    instrument=nothing, normalize=nothing) where {T<:AbstractFloat}
+    instrument=nothing, normalize=nothing,
+    id_kwargs::NamedTuple=NamedTuple()) where {T<:AbstractFloat}
 
     F = gdfm.factors
     T_obs, N = size(gdfm.X)
@@ -949,7 +960,8 @@ function _estimate_sdfm_gdfm_var(gdfm::GeneralizedDynamicFactorModel{T}, q::Int,
     else
         Q = compute_Q(factor_var, identification; horizon=H, check_func=sign_check,
                       narrative_check=narrative_check, max_draws=max_draws,
-                      transition_var=transition_var, regime_indicator=regime_indicator, rng=rng)
+                      transition_var=transition_var, regime_indicator=regime_indicator, rng=rng,
+                      id_kwargs...)
     end
 
     factor_irf = compute_irf(factor_var, Q, H)

--- a/src/gmm/gmm.jl
+++ b/src/gmm/gmm.jl
@@ -76,6 +76,8 @@ Fields:
 - J_pvalue: p-value for J-test
 - converged: Convergence flag
 - iterations: Number of iterations
+- first_stage_F: Minimum excluded-instrument partial first-stage F when
+  `X`/`Z` were supplied to `estimate_gmm` (IV-GMM); `NaN` otherwise
 """
 struct GMMModel{T<:AbstractFloat} <: AbstractGMMModel
     theta::Vector{T}
@@ -90,10 +92,12 @@ struct GMMModel{T<:AbstractFloat} <: AbstractGMMModel
     J_pvalue::T
     converged::Bool
     iterations::Int
+    first_stage_F::T
 
     function GMMModel{T}(theta::Vector{T}, vcov::Matrix{T}, n_moments::Int, n_params::Int,
                          n_obs::Int, weighting::GMMWeighting{T}, W::Matrix{T}, g_bar::Vector{T},
-                         J_stat::T, J_pvalue::T, converged::Bool, iterations::Int) where {T<:AbstractFloat}
+                         J_stat::T, J_pvalue::T, converged::Bool, iterations::Int,
+                         first_stage_F::Real=T(NaN)) where {T<:AbstractFloat}
         @assert length(theta) == n_params
         @assert size(vcov) == (n_params, n_params)
         @assert size(W) == (n_moments, n_moments)
@@ -103,7 +107,7 @@ struct GMMModel{T<:AbstractFloat} <: AbstractGMMModel
         # NaN marks an invalid p-value (J is not χ² under :identity weighting)
         @assert isnan(J_pvalue) || 0 <= J_pvalue <= 1
         new{T}(theta, vcov, n_moments, n_params, n_obs, weighting, W, g_bar,
-               J_stat, J_pvalue, converged, iterations)
+               J_stat, J_pvalue, converged, iterations, T(first_stage_F))
     end
 end
 
@@ -145,6 +149,18 @@ function Base.show(io::IO, m::GMMModel{T}) where {T}
         if isnan(m.J_pvalue)
             println(io, "Note: the J-statistic under identity weighting is not χ²-distributed;")
             println(io, "the p-value is invalid — use two-step/optimal weighting for the J-test.")
+        end
+    end
+    if isfinite(m.first_stage_F)
+        fs_data = Any["1st-stage F" _fmt(m.first_stage_F; digits=2)]
+        _pretty_table(io, fs_data;
+            title = "Weak-identification diagnostic",
+            column_labels = ["", ""],
+            alignment = [:l, :r],
+        )
+        if m.first_stage_F < T(10)
+            println(io, "Weak instruments: 1st-stage F = $(_fmt(m.first_stage_F; digits=2)) < 10 ",
+                        "(Stock & Yogo 2005).")
         end
     end
 end
@@ -333,7 +349,8 @@ end
     estimate_gmm(moment_fn::Function, theta0::AbstractVector{T}, data;
                  weighting::Symbol=:two_step, max_iter::Int=100,
                  tol::T=T(1e-8), hac::Bool=true, bandwidth::Int=0,
-                 bounds::Union{Nothing,ParameterTransform}=nothing) -> GMMModel{T}
+                 bounds::Union{Nothing,ParameterTransform}=nothing,
+                 X=nothing, Z=nothing, endogenous=nothing) -> GMMModel{T}
 
 Estimate parameters via Generalized Method of Moments.
 
@@ -351,6 +368,11 @@ Arguments:
 - bounds: Parameter bounds via `ParameterTransform` (default: nothing = unconstrained).
   When provided, optimization is performed in unconstrained space via bijective transforms,
   and standard errors are corrected via the delta method.
+- X, Z: Optional IV design (`n × k` regressors, `n × m` instruments). When both
+  are supplied, `first_stage_F` is the minimum excluded-instrument partial F
+  (Stock & Yogo 2005) and is printed by `report` / `gmm_summary`.
+- endogenous: Column indices of `X` treated as endogenous (default: every
+  non-constant column).
 
 Returns:
 - GMMModel with estimates, covariance, and J-test results
@@ -358,7 +380,9 @@ Returns:
 function estimate_gmm(moment_fn::Function, theta0::AbstractVector{T}, data;
                       weighting::Symbol=:two_step, max_iter::Int=100,
                       tol::T=T(1e-8), hac::Bool=true, bandwidth::Int=0,
-                      bounds::Union{Nothing,ParameterTransform}=nothing) where {T<:AbstractFloat}
+                      bounds::Union{Nothing,ParameterTransform}=nothing,
+                      X=nothing, Z=nothing,
+                      endogenous=nothing) where {T<:AbstractFloat}
     n_params = length(theta0)
 
     # Get dimensions from initial moment evaluation
@@ -501,8 +525,29 @@ function estimate_gmm(moment_fn::Function, theta0::AbstractVector{T}, data;
         (zero(T), one(T))  # Just identified
     end
 
+    fs_F = _gmm_first_stage_F(X, Z, endogenous, T)
+    if isfinite(fs_F) && fs_F < T(10)
+        @warn "Weak instruments: first-stage F = $(round(fs_F, digits=2)) < 10 (Stock & Yogo 2005)"
+    end
+
     GMMModel{T}(theta_hat, vcov, n_moments, n_params, n_obs, weighting_spec,
-                W_final, g_bar, J_stat, J_pvalue, converged, iterations)
+                W_final, g_bar, J_stat, J_pvalue, converged, iterations, fs_F)
+end
+
+"""Partial first-stage F for IV-GMM when `X` and `Z` are supplied; else `NaN`."""
+function _gmm_first_stage_F(X, Z, endogenous, ::Type{T}) where {T<:AbstractFloat}
+    (X === nothing || Z === nothing) && return T(NaN)
+    Xm = Matrix{T}(X)
+    Zm = Matrix{T}(Z)
+    size(Xm, 1) == size(Zm, 1) || throw(ArgumentError(
+        "X and Z must have the same number of rows, got $(size(Xm, 1)) and $(size(Zm, 1))"))
+    idx = if endogenous === nothing
+        Int[j for j in 1:size(Xm, 2) if maximum(abs, Xm[:, j] .- Xm[1, j]) > T(1e-12)]
+    else
+        Vector{Int}(endogenous)
+    end
+    isempty(idx) && return T(NaN)
+    _first_stage_f(Xm, Zm, idx)
 end
 
 # =============================================================================
@@ -556,7 +601,8 @@ function gmm_summary(model::GMMModel{T}) where {T<:AbstractFloat}
     (theta=model.theta, se=se, t_stats=t_stats, p_values=p_values,
      n_moments=model.n_moments, n_params=model.n_params, n_obs=model.n_obs,
      weighting=model.weighting.method, converged=model.converged,
-     iterations=model.iterations, j_test=j_result)
+     iterations=model.iterations, j_test=j_result,
+     first_stage_F=model.first_stage_F)
 end
 
 # =============================================================================

--- a/test/dsge/test_dsge.jl
+++ b/test/dsge/test_dsge.jl
@@ -2374,6 +2374,23 @@ end
     end
     @test_throws M.DSGESolveError compute_steady_state(spec_bad)
 
+    # #816: infeasible SS must be DSGESolveError, not LinearSolve world-age MethodError
+    spec_816 = @dsge begin
+        parameters: sigma = 0.01
+        endogenous: Y
+        exogenous: e
+        Y[t] = Y[t-1]^2 + 2 + sigma * e[t]
+    end
+    err816 = try
+        compute_steady_state(spec_816)
+        nothing
+    catch e
+        e
+    end
+    @test err816 isa M.DSGESolveError
+    @test occursin("equilibrium conditions", sprint(showerror, err816))
+    @test !(err816 isa MethodError)
+
     # S-17 (#224): is_stable / show read the cached eigenvalues, equal to recomputing eigvals(G1)
     spec = @dsge begin
         parameters: ρ = 0.9, σ = 1.0
@@ -7187,6 +7204,10 @@ end
     @test all(isfinite, sol_s.value_fn)
     v_ss = evaluate_value(sol_s, x_ss)
     @test isfinite(v_ss)
+    nodes_s = physical_nodes(sol_s)
+    @test size(nodes_s) == size(sol_s.collocation_nodes)
+    @test all(-1 .<= sol_s.collocation_nodes .<= 1)
+    @test isfinite(evaluate_value(sol_s, nodes_s[1, :]))
     y_ss = evaluate_policy(sol_s, x_ss)
     @test all(isfinite, y_ss)
     @test 0 < y_ss[1] < 10
@@ -7210,6 +7231,22 @@ end
     v_hi = evaluate_value(sol, [1.05 * k_ss, 0.0])
     @test v_hi > v_lo
     @test v_ss > log(spec.steady_state[1]) / (1 - spec.param_values[:β]) * 0.25
+end
+
+@testset "#829 collocation_nodes are Chebyshev coords; physical_nodes are levels" begin
+    nodes_u = sol.collocation_nodes
+    @test all(-1 .<= nodes_u .<= 1)
+    nodes_p = physical_nodes(sol)
+    @test size(nodes_p) == size(nodes_u)
+    lo = sol.state_bounds[:, 1]
+    hi = sol.state_bounds[:, 2]
+    for j in 1:size(nodes_p, 1)
+        for d in 1:size(nodes_p, 2)
+            @test lo[d] - 1e-10 <= nodes_p[j, d] <= hi[d] + 1e-10
+        end
+        @test isfinite(evaluate_value(sol, nodes_p[j, :]))
+    end
+    @test nodes_p ≈ MacroEconometricModels._scale_from_unit(nodes_u, sol.state_bounds)
 end
 
 @testset "Bellman residual is small after Howard PE" begin

--- a/test/factor/test_structural_dfm.jl
+++ b/test/factor/test_structural_dfm.jl
@@ -785,6 +785,23 @@ using MacroEconometricModels
             sprint(showerror, e)
         end
         @test occursin("long_run", msg) || occursin("fastica", msg)
+        @test occursin("lewis_tvv", msg)
+        @test occursin("sv_em", msg)
+        @test :lewis_tvv in MacroEconometricModels._SDFM_ID_METHODS
+        @test :sv_em in MacroEconometricModels._SDFM_ID_METHODS
+        @test :gmm_moments in MacroEconometricModels._SDFM_ID_METHODS
+        @test :lewis_tvv in MacroEconometricModels._SDFM_COMPUTE_Q_METHODS
+        @test :sv_em in MacroEconometricModels._SDFM_COMPUTE_Q_METHODS
+        sdfm_tvv = estimate_structural_dfm(X, q; r=2, identification=:lewis_tvv, p=1, H=8,
+            standardize=false, rng=Random.Xoshiro(830),
+            id_kwargs=(n_starts=2, max_iter=20, K=2))
+        @test sdfm_tvv.identification === :lewis_tvv
+        @test sdfm_tvv.Q' * sdfm_tvv.Q ≈ I(q) atol=1e-8
+        sdfm_sv = estimate_structural_dfm(X, q; r=2, identification=:sv_em, p=1, H=8,
+            standardize=false, rng=Random.Xoshiro(831),
+            id_kwargs=(maxiter=5, gibbs_draws=10, gibbs_burn=1, b_iter=1))
+        @test sdfm_sv.identification === :sv_em
+        @test sdfm_sv.Q' * sdfm_sv.Q ≈ I(q) atol=1e-8
     end
 
     @testset "stochastic identification is seed-identical" begin

--- a/test/gmm/test_gmm.jl
+++ b/test/gmm/test_gmm.jl
@@ -334,6 +334,7 @@ end
         @test s.weighting == :two_step
         @test s.converged isa Bool
         @test s.j_test isa NamedTuple
+        @test isnan(s.first_stage_F)
     end
 
     @testset "GMMModel StatsAPI interface" begin
@@ -764,7 +765,23 @@ end
                  overid_k=2, pi1=0.07)
     moment_fn(theta, dd) = dd[:, 4:6] .* (dd[:, 1] - dd[:, 2:3] * theta)
     res = estimate_gmm(moment_fn, [0.0, 0.0], hcat(dw.y, dw.X, dw.Z);
-                       weighting=:two_step, hac=false)
+                       weighting=:two_step, hac=false,
+                       X=dw.X, Z=dw.Z, endogenous=[2])
     @test res isa MacroEconometricModels.GMMModel
     @test all(isfinite, res.theta)
+    x = dw.X[:, 2]
+    Z = dw.Z
+    k = size(Z, 2)
+    Pz = Z * inv(Symmetric(Z' * Z)) * Z'
+    hand_F = ((dot(x, Pz * x) - dot(x, ones(length(x)))^2 / length(x)) / (k - 1)) /
+             ((dot(x, x) - dot(x, Pz * x)) / (length(x) - k))
+    @test res.first_stage_F ≈ hand_F rtol=1e-8
+    @test res.first_stage_F < 10          # weak-IV arm is below the Stock–Yogo rule of thumb
+    s = gmm_summary(res)
+    @test s.first_stage_F == res.first_stage_F
+    io = IOBuffer()
+    show(io, res)
+    shown = String(take!(io))
+    @test occursin("1st-stage F", shown)
+    @test occursin("Weak instruments", shown)
 end

--- a/test/gmm/test_gmm_serialization.jl
+++ b/test/gmm/test_gmm_serialization.jl
@@ -55,6 +55,17 @@ const _RSER11_GMM = ("GMMWeighting", "ParameterTransform")
         @test m2.weighting isa GMMWeighting{Float64}
         @test m2.weighting.method === m.weighting.method
         @test m2.theta == m.theta
+        @test isnan(m.first_stage_F) && isnan(m2.first_stage_F)
+    end
+
+    @testset "IV-GMM first_stage_F round-trip (#815)" begin
+        d = dgp_gmm(Xoshiro(815); kind=:iv, beta=[1.0, 0.5], n=200, hetero=false, overid_k=2)
+        moment_fn(theta, dd) = dd[:, 4:6] .* (dd[:, 1] - dd[:, 2:3] * theta)
+        m = estimate_gmm(moment_fn, [0.0, 0.0], hcat(d.y, d.X, d.Z);
+                         weighting=:identity, hac=false, X=d.X, Z=d.Z, endogenous=[2])
+        @test isfinite(m.first_stage_F)
+        m2 = _assert_roundtrip(m)
+        @test m2.first_stage_F == m.first_stage_F
     end
 
     @testset "ParameterTransform including Inf bounds" begin

--- a/test/var/test_uhlig.jl
+++ b/test/var/test_uhlig.jl
@@ -606,10 +606,6 @@ end
     # Satisfied candidate must have the lower (better) penalty.
     # Construct via a tiny helper that injects responses — or call _uhlig_penalty
     # on hand-built Qs once a VAR is estimated.
-    # Xoshiro(732) reproduces this testset's historical global-RNG stream
-    # exactly (verified); it stays on white noise because the r_uniq block
-    # below is seed-sensitive at ~50/50 across streams — see #814 (filed
-    # from DGP-02 #791).
     rng = Xoshiro(732)  # DGP-02: explicit rng
     n = 2
     Y = randn(rng, 200, n)
@@ -656,7 +652,8 @@ end
     @test spA[1] < spB[1]
 
     # Unique admissible rotation: zero on (2,1) plus a positive impact sign on (1,1)
-    # is Cholesky up to the sign, which the restriction pins.
+    # is Cholesky up to the sign, which the restriction pins. Sign-normalization
+    # (#814) makes this independent of the historical Xoshiro(732) stream.
     r_uniq = SVARRestrictions(n;
         zeros=[zero_restriction(2, 1)],
         signs=[sign_restriction(1, 1, :positive)])
@@ -668,10 +665,59 @@ end
     @test abs(u.irf[1, 2, 1]) < 1e-8
     @test all(sr -> sr.sign * u.irf[sr.horizon + 1, sr.variable, sr.shock] > 0,
               r_uniq.signs)
+    @test u.penalty < 0
 
     io = IOBuffer()
     show(io, u)
     @test occursin("lower", lowercase(String(take!(io))))
+end
+
+@testset "#814 uniquely-determined Uhlig sign is stable across streams" begin
+    n = 2
+    r_uniq = SVARRestrictions(n;
+        zeros=[zero_restriction(2, 1)],
+        signs=[sign_restriction(1, 1, :positive)])
+    uhlig_kw = (n_starts=FAST ? 3 : 10, n_refine=FAST ? 1 : 2,
+                max_iter_coarse=FAST ? 50 : 100, max_iter_fine=FAST ? 100 : 300)
+    # White-noise streams that previously converged ~50/50 (#814).
+    for seed in 1:6
+        rng = Xoshiro(seed)
+        m = estimate_var(randn(rng, 200, n), 1)
+        u = identify_uhlig(m, r_uniq, 5; rng=Xoshiro(seed + 100), uhlig_kw...)
+        @test u.converged
+        @test u.irf[1, 1, 1] > 0
+        @test abs(u.irf[1, 2, 1]) < 1e-8
+        @test u.penalty < 0
+    end
+    # Lower-triangular B0 DGP: previously 0/4 streams converged.
+    for seed in 7:10
+        d = dgp_var(Xoshiro(seed); A=[0.5 0.1; 0.2 0.4],
+                    B0=[1.0 0.0; 0.5 1.0], T=200, burn=50)
+        m = estimate_var(d.Y, 1)
+        u = identify_uhlig(m, r_uniq, 5; rng=Xoshiro(seed + 200), uhlig_kw...)
+        @test u.converged
+        @test u.irf[1, 1, 1] > 0
+        @test abs(u.irf[1, 2, 1]) < 1e-8
+        @test u.penalty < 0
+    end
+    # Direct penalty: the sign-flipped unique Q scores large positive, not 0.
+    rng = Xoshiro(11)
+    m = estimate_var(randn(rng, 200, n), 1)
+    Phi = MacroEconometricModels._compute_ma_coefficients(m, 1)
+    L = MacroEconometricModels.safe_cholesky(m.Sigma)
+    Q0 = MacroEconometricModels._uhlig_build_Q(Float64[], r_uniq, Phi, L, n)
+    impact = L * Q0
+    Qviol = copy(Q0)
+    Qviol[:, 1] .*= -1
+    Qsat = copy(Q0)
+    if impact[1, 1] < 0
+        Qsat, Qviol = Qviol, Qsat
+    end
+    pen_sat = MacroEconometricModels._uhlig_penalty_from_Q(Qsat, r_uniq, Phi, L, m, 1)
+    pen_viol = MacroEconometricModels._uhlig_penalty_from_Q(Qviol, r_uniq, Phi, L, m, 1)
+    @test pen_sat < 0
+    @test pen_viol > 1          # violated sign is weighted, not 0
+    @test pen_sat < pen_viol
 end
 
 @testset "SID-14 Uhlig rejects non-sign rejection types" begin


### PR DESCRIPTION
Patch on the `0.9` series: follow-ups from the v0.9.5–v0.9.6 backlog. `#817`–`#828` already shipped in v0.9.5 / v0.9.6.

Closes #814, closes #815, closes #816, closes #829, closes #830.

## Changes
- **#814** `identify_uhlig` sign-normalizes columns that carry a sign restriction (zeros survive a column flip). Uniquely determined rotations skip 0-parameter Nelder–Mead, which had been reporting penalty `0.0` without evaluating the objective.
- **#815** `estimate_gmm(...; X, Z, endogenous)` stores the Stock–Yogo partial first-stage F on `GMMModel.first_stage_F`. `report` / `gmm_summary` print it and warn when F < 10.
- **#816** Infeasible `compute_steady_state` throws `DSGESolveError` from the residual gate, not a LinearSolve world-age `MethodError` on the QR-fallback path.
- **#829** `ProjectionSolution.collocation_nodes` is documented as Chebyshev `[-1, 1]`. Exported `physical_nodes(sol)` rescales to physical levels for `evaluate_value` / `evaluate_policy`.
- **#830** `estimate_structural_dfm` accepts `:lewis_tvv`, `:sv_em`, and `:gmm_moments`, with `id_kwargs` forwarded to `compute_Q`.

Version bump: `Project.toml` / `docs/src/citation.md` / `docs/src/changelog.md` → `0.9.7`. Downstream `[compat]` of `MacroEconometricModels = "0.9"` still resolves. **Changed numerical output**: Uhlig uniquely-determined columns that previously returned the sign-flipped Cholesky now satisfy the imposed signs.

## Verification (observed this session)
- Uhlig: #814 multi-stream 43/43; full `test/var/test_uhlig.jl` green
- GMM: DGP-08 weak-ID + `gmm_summary`/`show`; serialization 86/86 (finite `first_stage_F` round-trip)
- DSGE FAST: `test/dsge/test_dsge.jl` 2639/2639 (infeasible SS → `DSGESolveError`; `physical_nodes` on tensor VFI)
- SDFM: `test/factor/test_structural_dfm.jl` 567/567 including live `:lewis_tvv` / `:sv_em` fits
- `verify_examples`: `gmm.md`, `factormodels.md`, `dsge_nonlinear.md` OK; changelog / citation / API pages have no `@example` blocks

## Scope notes
- No `gh-pages` deploy from this branch (docs go live via the normal release process).
- Tagging / JuliaRegistrator left to the release process after merge to `main`.